### PR TITLE
[codex] Harness Codex CLI Windows 호환성 개선

### DIFF
--- a/scripts/autopilot.py
+++ b/scripts/autopilot.py
@@ -6,12 +6,39 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
+IMPLEMENTATION_REASONING_EFFORT = "medium"
+REVIEW_REASONING_EFFORT = "xhigh"
+REVIEW_OUTPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "pass": {"type": "boolean"},
+        "summary": {"type": "string"},
+        "findings": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["pass", "summary", "findings"],
+    "additionalProperties": False,
+}
+
+
+def _resolve_codex_bin() -> str:
+    candidates = ("codex.cmd", "codex.exe", "codex") if sys.platform == "win32" else ("codex",)
+    for candidate in candidates:
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+    return candidates[0]
+
+
+CODEX_BIN = _resolve_codex_bin()
+CODEX_ENV_CONFIG = "shell_environment_policy.inherit=all"
 
 
 class AutopilotError(RuntimeError):
@@ -109,6 +136,7 @@ class AutopilotRunner:
         *,
         check: bool = True,
         timeout: int | None = None,
+        input_text: str | None = None,
     ) -> subprocess.CompletedProcess:
         result = subprocess.run(
             cmd,
@@ -116,6 +144,7 @@ class AutopilotRunner:
             capture_output=True,
             text=True,
             timeout=timeout,
+            input=input_text,
         )
         if check and result.returncode != 0:
             raise AutopilotError(self._command_failure(cmd, result))
@@ -223,6 +252,8 @@ class AutopilotRunner:
             "--push",
             "--step",
             str(step["step"]),
+            "--reasoning-effort",
+            IMPLEMENTATION_REASONING_EFFORT,
         ]
         if self.unsafe:
             cmd.append("--unsafe")
@@ -263,7 +294,7 @@ class AutopilotRunner:
             f"- `{self.phase}` Step {step['step']} `{step['name']}` 범위를 구현했습니다.\n"
             f"- 산출물: {summary}\n\n"
             "## 변경 이유\n"
-            "- Harness 작업을 작은 step 단위로 리뷰하고 안전하게 병합하기 위해 분리했습니다.\n\n"
+            f"{self._pr_change_reason(summary, task)}\n\n"
             "## 주요 변경 사항\n"
             f"- Step 작업: {task}\n"
             f"{changed_section}\n\n"
@@ -273,7 +304,20 @@ class AutopilotRunner:
             "## 참고 사항\n"
             f"- 브랜치: `{branch}`\n"
             "- Draft PR로 생성하며 자체 리뷰 gate 통과 시 ready 전환 후 squash merge합니다.\n"
+            f"- Codex 지능은 구현 `{IMPLEMENTATION_REASONING_EFFORT}`, 리뷰 `{REVIEW_REASONING_EFFORT}`로 실행합니다.\n"
         )
+
+    def _pr_change_reason(self, summary: str, task: str) -> str:
+        task_text = self._sentence_fragment(task) or "현재 step"
+        summary_text = self._sentence_fragment(summary) or "step 실행 결과를 반영함"
+        return (
+            f"- 이 PR은 \"{task_text}\" 요구사항을 완료하기 위한 변경입니다.\n"
+            f"- 실제 변경 결과: {summary_text}."
+        )
+
+    @staticmethod
+    def _sentence_fragment(text: str) -> str:
+        return text.strip().rstrip(".")
 
     def _step_from_index(self, step_num: int) -> dict | None:
         index = self._load_phase_index()
@@ -365,11 +409,36 @@ class AutopilotRunner:
     def _run_codex_review(self, step: dict) -> ReviewResult:
         prompt = self._codex_review_prompt(step)
         before_status = self._worktree_status()
-        result = self._run(
-            ["codex", "exec", "review", "--base", f"origin/{self.base}", "--json", prompt],
-            check=False,
-            timeout=1800,
-        )
+        schema_path = self._write_review_output_schema()
+        last_message_path = self._temporary_path(".txt")
+        try:
+            result = self._run(
+                [
+                    CODEX_BIN,
+                    "exec",
+                    "-c",
+                    f'model_reasoning_effort="{REVIEW_REASONING_EFFORT}"',
+                    "-c",
+                    CODEX_ENV_CONFIG,
+                    "--output-schema",
+                    str(schema_path),
+                    "--output-last-message",
+                    str(last_message_path),
+                    "--json",
+                    "-",
+                ],
+                check=False,
+                timeout=1800,
+                input_text=prompt,
+            )
+            last_message = (
+                last_message_path.read_text(encoding="utf-8")
+                if last_message_path.exists()
+                else ""
+            )
+        finally:
+            schema_path.unlink(missing_ok=True)
+            last_message_path.unlink(missing_ok=True)
         after_status = self._worktree_status()
         if after_status != before_status:
             return ReviewResult(
@@ -384,11 +453,27 @@ class AutopilotRunner:
         if result.returncode != 0:
             return ReviewResult(
                 False,
-                [self._command_failure(["codex", "exec", "review", "--json", "<review-prompt>"], result)],
+                [
+                    self._command_failure(
+                        [
+                            "codex",
+                            "exec",
+                            "-c",
+                            f'model_reasoning_effort="{REVIEW_REASONING_EFFORT}"',
+                            "-c",
+                            CODEX_ENV_CONFIG,
+                            "--json",
+                            "<review-prompt>",
+                        ],
+                        result,
+                    )
+                ],
                 "자체 리뷰 실행 실패",
                 codex_passed=False,
             )
-        parsed = self._parse_review_result(result.stdout)
+        parsed = self._parse_review_result(result.stdout) or self._parse_review_result(last_message)
+        if parsed is None:
+            parsed = self._parse_native_review_text(last_message)
         if parsed is None:
             return ReviewResult(
                 False,
@@ -397,6 +482,15 @@ class AutopilotRunner:
                 codex_passed=False,
             )
         return parsed
+
+    def _write_review_output_schema(self) -> Path:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json", delete=False) as file:
+            json.dump(REVIEW_OUTPUT_SCHEMA, file)
+            return Path(file.name)
+
+    def _temporary_path(self, suffix: str) -> Path:
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as file:
+            return Path(file.name)
 
     def _worktree_status(self) -> str:
         result = self._git("status", "--short", "--untracked-files=all", check=False)
@@ -409,6 +503,7 @@ class AutopilotRunner:
         step_name = step.get("name", "unknown")
         phase_readme = f"phases/{self.phase}/README.md"
         step_file = f"phases/{self.phase}/step{step_num}.md"
+        python_bin = str(Path(sys.executable))
         return (
             "Read-only review only. Do not modify files. "
             f"Review the current branch diff against origin/{self.base} for Harness project rules. "
@@ -420,6 +515,8 @@ class AutopilotRunner:
             "Missing functionality assigned to future steps is not a blocker. "
             "Implementing future-step scope inside the current step is a blocker. "
             "Focus on blockers: bugs, missing tests, MVP scope violations, API or CLI contract violations, build/test risk. "
+            f"The runner already executed local checks before this review. If you rerun Python checks on Windows, use `{python_bin}` "
+            "instead of assuming `python` or `py` is available on PATH. "
             "Return only JSON with keys: pass (boolean), summary (string), findings (array of strings)."
         )
 
@@ -485,6 +582,31 @@ class AutopilotRunner:
                 nested = self._try_parse_review_payload(value)
                 if nested is not None:
                     return nested
+        return None
+
+    def _parse_native_review_text(self, text: str) -> ReviewResult | None:
+        stripped = text.strip()
+        if not stripped:
+            return None
+
+        findings = [
+            line.strip()
+            for line in stripped.splitlines()
+            if re.match(r"^[-*]\s+\[P[0-3]\]", line.strip())
+        ]
+        if findings:
+            return ReviewResult(False, findings, "자체 리뷰에서 발견사항을 보고했습니다.", codex_passed=False)
+
+        lowered = stripped.lower()
+        pass_markers = (
+            "no issues found",
+            "no findings",
+            "블로커 없음",
+            "발견사항 없음",
+            "문제 없음",
+        )
+        if any(marker in lowered for marker in pass_markers):
+            return ReviewResult(True, [], stripped, codex_passed=True)
         return None
 
     # --- issue recording ---
@@ -560,7 +682,20 @@ class AutopilotRunner:
             f"{review.to_markdown()}\n\n"
             "수정 후 가능한 검증을 실행하고, 수정한 파일은 working tree에 남겨두세요."
         )
-        self._run(["codex", "exec", "--json", prompt], timeout=1800)
+        self._run(
+            [
+                CODEX_BIN,
+                "exec",
+                "-c",
+                f'model_reasoning_effort="{IMPLEMENTATION_REASONING_EFFORT}"',
+                "-c",
+                CODEX_ENV_CONFIG,
+                "--json",
+                "-",
+            ],
+            timeout=1800,
+            input_text=prompt,
+        )
 
     def _commit_dirty_fix(self, step: dict):
         status = self._git("status", "--short", "--untracked-files=all").stdout.strip()

--- a/scripts/execute.py
+++ b/scripts/execute.py
@@ -9,6 +9,7 @@ Usage:
 import argparse
 import contextlib
 import json
+import shutil
 import subprocess
 import sys
 import threading
@@ -21,6 +22,19 @@ from typing import Optional
 import checks
 
 ROOT = Path(__file__).resolve().parent.parent
+
+
+def _resolve_codex_bin() -> str:
+    candidates = ("codex.cmd", "codex.exe", "codex") if sys.platform == "win32" else ("codex",)
+    for candidate in candidates:
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+    return candidates[0]
+
+
+CODEX_BIN = _resolve_codex_bin()
+CODEX_ENV_CONFIG = "shell_environment_policy.inherit=all"
 
 
 @contextlib.contextmanager
@@ -63,7 +77,8 @@ class StepExecutor:
     def __init__(self, phase_dir_name: str, *, auto_push: bool = False,
                  unsafe: bool = False, branch_name: Optional[str] = None,
                  step_number: Optional[int] = None,
-                 next_step_only: bool = False):
+                 next_step_only: bool = False,
+                 reasoning_effort: Optional[str] = None):
         self._root = str(ROOT)
         self._phases_dir = ROOT / "phases"
         self._phase_dir = self._phases_dir / phase_dir_name
@@ -74,6 +89,7 @@ class StepExecutor:
         self._branch_name = branch_name
         self._step_number = step_number
         self._next_step_only = next_step_only
+        self._reasoning_effort = reasoning_effort
 
         if not self._phase_dir.is_dir():
             print(f"ERROR: {self._phase_dir} not found")
@@ -224,22 +240,22 @@ class StepExecutor:
         sections = []
         agents_md = ROOT / "AGENTS.md"
         if agents_md.exists():
-            sections.append(f"## 프로젝트 규칙 (AGENTS.md)\n\n{agents_md.read_text()}")
+            sections.append(f"## 프로젝트 규칙 (AGENTS.md)\n\n{agents_md.read_text(encoding='utf-8')}")
         phase_dir = getattr(self, "_phase_dir", None)
         phase_readme = phase_dir / "README.md" if phase_dir is not None else None
         if phase_readme is not None and phase_readme.exists():
             sections.append(
                 f"## 현재 Phase README ({getattr(self, '_phase_dir_name', phase_readme.parent.name)}/README.md)\n\n"
-                f"{phase_readme.read_text()}"
+                f"{phase_readme.read_text(encoding='utf-8')}"
             )
         docs_dir = ROOT / "docs"
         if docs_dir.is_dir():
             for doc in sorted(docs_dir.glob("*.md")):
-                sections.append(f"## {doc.stem}\n\n{doc.read_text()}")
+                sections.append(f"## {doc.stem}\n\n{doc.read_text(encoding='utf-8')}")
             adr_dir = docs_dir / "adr"
             if adr_dir.is_dir():
                 for doc in sorted(adr_dir.glob("*.md")):
-                    sections.append(f"## adr/{doc.stem}\n\n{doc.read_text()}")
+                    sections.append(f"## adr/{doc.stem}\n\n{doc.read_text(encoding='utf-8')}")
         return "\n\n---\n\n".join(sections) if sections else ""
 
     def _load_command_context(self) -> str:
@@ -312,13 +328,17 @@ class StepExecutor:
             print(f"  ERROR: {step_file} not found")
             sys.exit(1)
 
-        prompt = preamble + step_file.read_text()
-        cmd = ["codex", "exec", "--json"]
+        prompt = preamble + step_file.read_text(encoding="utf-8")
+        cmd = [CODEX_BIN, "exec"]
+        if self._reasoning_effort:
+            cmd.extend(["-c", f'model_reasoning_effort="{self._reasoning_effort}"'])
+        cmd.extend(["-c", CODEX_ENV_CONFIG])
+        cmd.append("--json")
         if self._unsafe:
             cmd.append("--dangerously-bypass-approvals-and-sandbox")
-        cmd.append(prompt)
+        cmd.append("-")
         result = subprocess.run(
-            cmd,
+            cmd, input=prompt,
             cwd=self._root, capture_output=True, text=True, timeout=1800,
         )
 
@@ -333,7 +353,7 @@ class StepExecutor:
             "stdout": result.stdout, "stderr": result.stderr,
         }
         out_path = self._phase_dir / f"step{step_num}-output.json"
-        with open(out_path, "w") as f:
+        with open(out_path, "w", encoding="utf-8") as f:
             json.dump(output, f, indent=2, ensure_ascii=False)
 
         return output
@@ -552,6 +572,11 @@ def main():
     parser.add_argument("--unsafe", action="store_true", help="Run codex exec with sandbox and approval bypass")
     parser.add_argument("--step", type=int, help="Run only this pending step number")
     parser.add_argument("--next-step-only", action="store_true", help="Run only the next pending step")
+    parser.add_argument(
+        "--reasoning-effort",
+        choices=("minimal", "low", "medium", "high", "xhigh"),
+        help="Override Codex model_reasoning_effort for step implementation",
+    )
     args = parser.parse_args()
 
     if args.step is not None and args.next_step_only:
@@ -564,6 +589,7 @@ def main():
         branch_name=args.branch,
         step_number=args.step,
         next_step_only=args.next_step_only,
+        reasoning_effort=args.reasoning_effort,
     ).run()
 
 

--- a/scripts/test_autopilot.py
+++ b/scripts/test_autopilot.py
@@ -129,6 +129,20 @@ def test_step_success_creates_draft_pr_comments_and_merges(runner, tmp_repo):
     assert ("pr", "merge", "https://github.com/org/repo/pull/2", "--squash", "--delete-branch") in gh_calls
 
 
+def test_pr_body_uses_step_specific_change_reason(runner, tmp_repo):
+    _mark_step_complete(tmp_repo, 1, "API 계약 타입을 추가함")
+    runner._changed_files = lambda: ["app/shared/src/contracts/agent.ts"]
+
+    body = runner._pr_body(
+        "codex/0-mvp-step1-api-layer",
+        {"step": 1, "name": "api-layer"},
+    )
+
+    assert "Harness 작업을 작은 step 단위로 리뷰하고 안전하게 병합하기 위해 분리했습니다." not in body
+    assert "이 PR은 \"API 레이어를 만든다\" 요구사항을 완료하기 위한 변경입니다." in body
+    assert "실제 변경 결과: API 계약 타입을 추가함." in body
+
+
 def test_review_fail_records_issue_and_leaves_pr_open(runner, tmp_repo):
     gh_calls = []
     runner.max_review_fixes = 0
@@ -295,14 +309,19 @@ def test_codex_review_prompt_excludes_issue_records_and_uses_step_contract(runne
     assert "Current Harness step is Step 1 `api-layer`" in prompt
     assert "Missing functionality assigned to future steps is not a blocker" in prompt
     assert "Implementing future-step scope inside the current step is a blocker" in prompt
+    assert str(Path(sys.executable)) in prompt
+    assert "instead of assuming `python` or `py` is available on PATH" in prompt
 
 
-def test_codex_review_uses_read_only_review_subcommand(runner):
+def test_codex_review_uses_step_scoped_exec_prompt(runner):
     seen = {}
     runner._git = lambda *args, check=True: cp(stdout="")
 
-    def fake_run(cmd, check=True, timeout=None):
+    def fake_run(cmd, check=True, timeout=None, input_text=None):
         seen["cmd"] = cmd
+        seen["input_text"] = input_text
+        schema_path = Path(cmd[cmd.index("--output-schema") + 1])
+        seen["schema"] = json.loads(schema_path.read_text(encoding="utf-8"))
         return cp(stdout='{"pass": true, "summary": "ok", "findings": []}')
 
     runner._run = fake_run
@@ -310,7 +329,57 @@ def test_codex_review_uses_read_only_review_subcommand(runner):
     review = runner._run_codex_review({"step": 0, "name": "project-scaffold"})
 
     assert review.passed is True
-    assert seen["cmd"][:6] == ["codex", "exec", "review", "--base", "origin/main", "--json"]
+    assert seen["cmd"][:2] == [ap.CODEX_BIN, "exec"]
+    assert "review" not in seen["cmd"][2:]
+    assert "--base" not in seen["cmd"]
+    assert ap.CODEX_ENV_CONFIG in seen["cmd"]
+    assert "--output-schema" in seen["cmd"]
+    assert seen["schema"]["required"] == ["pass", "summary", "findings"]
+    assert "--output-last-message" in seen["cmd"]
+    assert "--json" in seen["cmd"]
+    assert seen["cmd"][-1] == "-"
+    assert seen["input_text"].startswith("Read-only review only.")
+    assert "Current Harness step is Step 0 `project-scaffold`" in seen["input_text"]
+
+
+def test_codex_review_parses_output_last_message(runner):
+    runner._git = lambda *args, check=True: cp(stdout="")
+
+    def fake_run(cmd, check=True, timeout=None, input_text=None):
+        last_message_path = Path(cmd[cmd.index("--output-last-message") + 1])
+        last_message_path.write_text('{"pass": true, "summary": "ok", "findings": []}', encoding="utf-8")
+        return cp(stdout='{"type":"started"}')
+
+    runner._run = fake_run
+
+    review = runner._run_codex_review({"step": 0, "name": "project-scaffold"})
+
+    assert review.passed is True
+    assert review.summary == "ok"
+
+
+def test_codex_review_parses_native_priority_findings(runner):
+    runner._git = lambda *args, check=True: cp(stdout="")
+
+    def fake_run(cmd, check=True, timeout=None, input_text=None):
+        last_message_path = Path(cmd[cmd.index("--output-last-message") + 1])
+        last_message_path.write_text(
+            "Review comment:\n\n"
+            "- [P2] Pass step-scoped review instructions to Codex - scripts/autopilot.py:410\n"
+            "  The review lacks the step contract.",
+            encoding="utf-8",
+        )
+        return cp(stdout='{"type":"turn.completed"}')
+
+    runner._run = fake_run
+
+    review = runner._run_codex_review({"step": 0, "name": "project-scaffold"})
+
+    assert review.passed is False
+    assert review.codex_passed is False
+    assert review.findings == [
+        "- [P2] Pass step-scoped review instructions to Codex - scripts/autopilot.py:410"
+    ]
 
 
 def test_run_step_uses_current_python_executable(runner):
@@ -326,13 +395,58 @@ def test_run_step_uses_current_python_executable(runner):
     runner._run_step("codex/test", step)
 
     assert seen["cmd"][:2] == [sys.executable, "scripts/execute.py"]
+    assert "--reasoning-effort" in seen["cmd"]
+    assert seen["cmd"][seen["cmd"].index("--reasoning-effort") + 1] == "medium"
+    assert seen["timeout"] == 1800
+
+
+def test_codex_review_uses_xhigh_reasoning_effort(runner):
+    seen = {}
+    runner._git = lambda *args, check=True: cp(stdout="")
+
+    def fake_run(cmd, check=True, timeout=None, input_text=None):
+        seen["cmd"] = cmd
+        return cp(stdout='{"pass": true, "summary": "ok", "findings": []}')
+
+    runner._run = fake_run
+
+    review = runner._run_codex_review({"step": 0, "name": "project-scaffold"})
+
+    assert review.passed is True
+    assert "-c" in seen["cmd"]
+    assert 'model_reasoning_effort="xhigh"' in seen["cmd"]
+    assert ap.CODEX_ENV_CONFIG in seen["cmd"]
+
+
+def test_codex_fix_uses_medium_reasoning_effort(runner, tmp_repo):
+    seen = {}
+    issue = ap.IssueRecord(1, "title", "body", tmp_repo / "issues" / "issue-1.md", "")
+
+    def fake_run(cmd, check=True, timeout=None, input_text=None):
+        seen["cmd"] = cmd
+        seen["input_text"] = input_text
+        seen["timeout"] = timeout
+        return cp()
+
+    runner._run = fake_run
+    runner._invoke_codex_fix(
+        issue,
+        "codex/test",
+        {"step": 0, "name": "project-scaffold"},
+        ap.ReviewResult(False, ["finding"], "failed"),
+        1,
+    )
+
+    assert seen["cmd"][:4] == [ap.CODEX_BIN, "exec", "-c", 'model_reasoning_effort="medium"']
+    assert ap.CODEX_ENV_CONFIG in seen["cmd"]
+    assert seen["input_text"].startswith("당신은 Harness step PR 자동 리뷰 수정 담당자입니다.")
     assert seen["timeout"] == 1800
 
 
 def test_codex_review_fails_if_worktree_changes(runner):
     statuses = iter([cp(stdout=""), cp(stdout=" M src/app.py\n")])
     runner._git = lambda *args, check=True: next(statuses)
-    runner._run = lambda cmd, check=True, timeout=None: cp(
+    runner._run = lambda cmd, check=True, timeout=None, input_text=None: cp(
         stdout='{"pass": true, "summary": "ok", "findings": []}'
     )
 

--- a/scripts/test_execute.py
+++ b/scripts/test_execute.py
@@ -555,12 +555,28 @@ class TestInvokeCodex:
             output = executor._invoke_codex(step, preamble)
 
         cmd = mock_run.call_args[0][0]
-        assert cmd[0] == "codex"
+        assert cmd[0] == ex.CODEX_BIN
         assert cmd[1] == "exec"
         assert "--json" in cmd
+        assert ex.CODEX_ENV_CONFIG in cmd
+        assert "model_reasoning_effort" not in " ".join(cmd)
         assert "--dangerously-bypass-approvals-and-sandbox" not in cmd
-        assert "PREAMBLE" in cmd[-1]
-        assert "UI를 구현하세요" in cmd[-1]
+        assert cmd[-1] == "-"
+        assert "PREAMBLE" in mock_run.call_args.kwargs["input"]
+        assert "UI를 구현하세요" in mock_run.call_args.kwargs["input"]
+
+    def test_reasoning_effort_adds_codex_config(self, executor):
+        executor._reasoning_effort = "medium"
+        mock_result = MagicMock(returncode=0, stdout="{}", stderr="")
+        step = {"step": 2, "name": "ui"}
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            executor._invoke_codex(step, "preamble")
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:4] == [ex.CODEX_BIN, "exec", "-c", 'model_reasoning_effort="medium"']
+        assert ex.CODEX_ENV_CONFIG in cmd
+        assert "--json" in cmd
 
     def test_unsafe_adds_bypass_flag(self, executor):
         executor._unsafe = True
@@ -675,8 +691,26 @@ class TestMainCli:
             "branch_name": "codex/test",
             "step_number": 2,
             "next_step_only": False,
+            "reasoning_effort": None,
             "ran": True,
         }
+
+    def test_cli_passes_reasoning_effort(self):
+        captured = {}
+
+        class DummyExecutor:
+            def __init__(self, phase_dir, **kwargs):
+                captured["phase_dir"] = phase_dir
+                captured.update(kwargs)
+
+            def run(self):
+                captured["ran"] = True
+
+        with patch("sys.argv", ["execute.py", "0-mvp", "--reasoning-effort", "medium"]):
+            with patch.object(ex, "StepExecutor", DummyExecutor):
+                ex.main()
+
+        assert captured["reasoning_effort"] == "medium"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
﻿## 작업 내용
- Harness 템플릿의 Codex CLI 실행 경계를 Windows와 macOS/Linux 양쪽에서 안정적으로 동작하도록 수정했습니다.
- autopilot PR 본문의 `변경 이유`가 고정 문구가 아니라 실제 step 작업과 summary를 반영하도록 개선했습니다.
- 새 동작을 고정하는 execute/autopilot 회귀 테스트를 추가했습니다.

## 변경 이유
- Windows에서 Python `subprocess.run(["codex", ...])`가 npm shim을 안정적으로 찾지 못하고, 긴 한글 prompt를 CLI 인자로 넘길 때 깨질 수 있었습니다.
- `codex exec review --base ... [PROMPT]` 조합은 현재 CLI 계약과 맞지 않아 review gate가 실패할 수 있었습니다.
- autopilot이 만든 PR 설명의 변경 이유가 실제 변경 내용이 아닌 템플릿 내부 운영 이유로 표시됐습니다.

## 주요 변경 사항
- Windows에서는 `codex.cmd`, `codex.exe`, `codex` 순서로 Codex 실행 파일을 탐색하고, 비-Windows는 기존처럼 `codex`를 사용합니다.
- `codex exec` prompt를 CLI 인자 대신 stdin으로 전달하고 `shell_environment_policy.inherit=all`을 적용합니다.
- autopilot review gate를 일반 `codex exec --json -` + `--output-schema` + `--output-last-message` 방식으로 전환했습니다.
- `python scripts/execute.py <phase> --reasoning-effort medium` 옵션을 추가했습니다.

## 테스트
- `python -m pytest scripts/test_autopilot.py scripts/test_execute.py scripts/test_doctor.py` 통과, 103 passed
- `python -m pytest scripts` 통과, 120 passed
- `git diff --check origin/main...HEAD` 통과
- `python scripts/doctor.py --template` 통과
- `python scripts/checks.py --stage manual` 실패: 템플릿 원본의 `test`, `build` 명령이 아직 설정되지 않은 기존 상태입니다.

## 참고 사항
- `.sh` hook wrapper와 LF 정책은 유지했습니다.
