### PR TITLE
fix: Codex hook Python 실행 명령 개선

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .codex/hooks/tdd-guard.py tdd-pre-tool-use",
+            "command": "python3 .codex/hooks/tdd-guard.py tdd-pre-tool-use",
             "timeout": 10,
             "statusMessage": "Checking TDD guard"
           }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .codex/hooks/tdd-guard.py pre-tool-use",
+            "command": "python3 .codex/hooks/tdd-guard.py pre-tool-use",
             "timeout": 10,
             "statusMessage": "Checking command policy"
           }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .codex/hooks/tdd-guard.py permission-request",
+            "command": "python3 .codex/hooks/tdd-guard.py permission-request",
             "timeout": 10,
             "statusMessage": "Checking approval policy"
           }
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .codex/hooks/tdd-guard.py stop",
+            "command": "python3 .codex/hooks/tdd-guard.py stop",
             "timeout": 120,
             "statusMessage": "Running project checks"
           }

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Windows PowerShell:
 git config core.hooksPath .githooks
 ```
 
-Windows에서는 Python 설치 시 `python.exe`를 PATH에 추가해야 Codex hook이
-PowerShell에서 바로 실행됩니다.
+Codex hook은 `.codex/hooks.json`에서 `python3` 명령으로 실행됩니다. Windows에서는
+Python 설치 후 앱 실행 환경의 PATH에서 `python3`가 동작하는지 확인합니다.
 
 Codex 앱의 tool hook은 터미널 명령이 아니라 앱 설정에서 켭니다.
 
@@ -161,7 +161,8 @@ autopilot은 step마다 아래 루프를 반복합니다.
 
 복사한 인스턴스는 `.codex/project-profile.json`의 `templateVersion` 마커로
 템플릿과의 동기화 상태를 추적하고, 템플릿 소유 단위(`scripts/`,
-`.agents/skills/`, hook 설정)를 통째로 덮어쓰는 방식으로 업그레이드합니다.
+`.agents/skills/harness/`, `.agents/skills/review/`, hook 설정)를 통째로
+덮어쓰는 방식으로 업그레이드합니다. 프로젝트 전용 skill 디렉터리는 보존합니다.
 파일 소유 구분과 절차는 [guides/UPGRADE.md](guides/UPGRADE.md)를 참조합니다.
 
 ## 템플릿 자체 개발

--- a/guides/UPGRADE.md
+++ b/guides/UPGRADE.md
@@ -20,20 +20,30 @@
 | 단위 | 소유 | 업그레이드 시 |
 | --- | --- | --- |
 | `scripts/` (테스트 포함) | 템플릿 | 통째로 덮어쓰기 |
-| `.agents/skills/` | 템플릿 | 통째로 덮어쓰기 |
+| `.agents/skills/harness/`, `.agents/skills/review/` | 템플릿 공통 스킬 | 각 디렉터리만 통째로 덮어쓰기 |
 | `.githooks/`, `.codex/hooks/`, `.codex/hooks.json`, `.codex/config.toml`, `.gitattributes` | 템플릿 | 통째로 덮어쓰기 |
 | `guides/PROMPTS.md`, `guides/CONFIGURATION.md`, `guides/UPGRADE.md` | 템플릿 | 통째로 덮어쓰기 |
 | `.github/workflows/template-ci.yml` | 템플릿 전용 | 인스턴스에는 복사하지 않음 |
+| `.agents/skills/<project-skill>/` | 프로젝트 | 덮어쓰지 않음 |
 | `AGENTS.md`, `docs/`, `phases/`, `issues/`, `archive/` | 프로젝트 | 덮어쓰지 않음 |
 | `.codex/project-profile.json`, `.codex/scope-rules.json`, `phases/*/scope-rules.json` | 프로젝트 | 덮어쓰지 않음. 단 `templateVersion` 키만 갱신 |
+
+`.agents/skills/`는 템플릿 공통 스킬과 프로젝트 전용 스킬이 함께 들어갈 수 있는
+혼합 루트입니다. 업그레이드할 때 루트 전체를 삭제하거나 동기화하지 말고,
+템플릿이 소유한 공통 스킬 디렉터리만 이름 기준으로 교체합니다. 템플릿에 새 공통
+스킬이 추가되면 이 표에 해당 디렉터리를 먼저 추가한 뒤 인스턴스 업그레이드
+절차에 포함합니다. 프로젝트 전용 스킬은 템플릿 공통 스킬과 같은 이름을 쓰지
+않습니다. 이름이 충돌하면 업그레이드 전에 프로젝트 스킬 이름을 바꾸거나 공통
+스킬 편입 여부를 결정합니다.
 
 `.github/workflows/template-ci.yml`은 템플릿 repo 전용 검증입니다. 실제 프로젝트
 인스턴스에는 복사하지 않고, 이미 복사했다면 삭제합니다. 실제 프로젝트의 CI는
 `docs/COMMANDS.md`에 확정한 `lint`, `test`, `build` 명령 기준으로 별도 작성합니다.
 
-인스턴스에서 `scripts/` 같은 템플릿 소유 파일을 직접 고치면 다음 업그레이드 때
-덮어써 사라집니다. harness 개선이 필요하면 템플릿 repo에 먼저 반영해 버전을
-올리고, 업그레이드 절차로 인스턴스에 가져옵니다.
+인스턴스에서 `scripts/`나 `.agents/skills/harness/` 같은 템플릿 소유 파일을 직접
+고치면 다음 업그레이드 때 덮어써 사라집니다. harness나 review 공통 스킬 개선이
+필요하면 템플릿 repo에 먼저 반영해 버전을 올리고, 업그레이드 절차로 인스턴스에
+가져옵니다. 프로젝트별 작업 방식은 별도 프로젝트 전용 스킬 디렉터리로 둡니다.
 
 ## 업그레이드 절차
 

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -53,6 +53,7 @@ PLACEHOLDER_FILES = [
 PLACEHOLDER_PATTERN = re.compile(r"<[^>\n]+>|TODO|TBD")
 MODES = ("template", "instance")
 LEGACY_HOOK_MARKERS = ("/bin/bash", "/usr/bin/python3", "$(git rev-parse")
+PYTHON_ONLY_HOOK_MARKER = "python .codex/hooks/tdd-guard.py"
 # phase 파일 형식의 살아있는 예시. SKILL.md 산문과 달리 스키마가 깨지면
 # template 모드 doctor(및 CI)가 잡아내므로, 형식 변경 시 예시도 함께 갱신된다.
 EXAMPLE_PHASE_DIR = "phases/0-example"
@@ -159,8 +160,10 @@ def _template_contract_issues(root: Path) -> list[str]:
             issues.append(f"{rel} is missing.")
 
     hooks_json = _read_text(root, ".codex/hooks.json")
-    if "tdd-guard.py" not in hooks_json:
-        issues.append(".codex/hooks.json must call the cross-platform tdd-guard.py launcher.")
+    if "python3 .codex/hooks/tdd-guard.py" not in hooks_json:
+        issues.append(".codex/hooks.json must call tdd-guard.py through python3, not bare python.")
+    if PYTHON_ONLY_HOOK_MARKER in hooks_json:
+        issues.append(".codex/hooks.json still depends on a bare `python` command.")
     if any(marker in hooks_json for marker in LEGACY_HOOK_MARKERS):
         issues.append(".codex/hooks.json still contains legacy POSIX shell hook commands.")
 

--- a/scripts/tests/test_doctor.py
+++ b/scripts/tests/test_doctor.py
@@ -152,7 +152,7 @@ def _write_cross_platform_hook_contract(root: Path):
                             "hooks": [
                                 {
                                     "type": "command",
-                                    "command": "python .codex/hooks/tdd-guard.py stop",
+                                    "command": "python3 .codex/hooks/tdd-guard.py stop",
                                 }
                             ]
                         }
@@ -274,8 +274,21 @@ def test_template_mode_detects_legacy_hook_command(tmp_path):
 
     issues = doctor.collect_issues(tmp_path, "template")
 
-    assert any("cross-platform tdd-guard.py" in issue for issue in issues)
+    assert any("through python3" in issue for issue in issues)
     assert any("legacy POSIX shell hook commands" in issue for issue in issues)
+
+
+def test_template_mode_detects_bare_python_hook_command(tmp_path):
+    _write_template_files(tmp_path)
+    (tmp_path / ".codex" / "hooks.json").write_text(
+        '{ "command": "python .codex/hooks/tdd-guard.py stop" }',
+        encoding="utf-8",
+    )
+
+    issues = doctor.collect_issues(tmp_path, "template")
+
+    assert any("through python3" in issue for issue in issues)
+    assert any("bare `python` command" in issue for issue in issues)
 
 
 def test_template_mode_detects_missing_line_ending_policy(tmp_path):


### PR DESCRIPTION
## 작업 내용
- Codex hook 설정의 Python 실행 명령을 `python3` 기준으로 변경
- bare `python` hook 호출을 doctor 템플릿 검증에서 회귀로 감지하도록 수정
- 프로젝트 전용 skill 보존 규칙과 hook 실행 명령을 README/업그레이드 가이드에 반영

## 변경 이유
- `python` 명령이 없는 macOS/Linux/CI 환경에서 Codex hook이 시작부터 실패할 수 있는 문제를 줄이기 위해 필요합니다.
- `.agents/skills/` 전체를 템플릿 소유로 안내하면 프로젝트 전용 skill이 업그레이드 중 삭제될 수 있어 소유권 구분을 명확히 했습니다.

## 주요 변경 사항
- `.codex/hooks.json`의 hook 명령을 `python3 .codex/hooks/tdd-guard.py ...`로 변경
- `scripts/doctor.py`에 bare `python` hook 호출 검출 추가
- `scripts/tests/test_doctor.py`에 회귀 테스트 추가
- `README.md`, `guides/UPGRADE.md` 문서 정합성 갱신

## 테스트
- `python scripts/doctor.py --template`
- `python -m pytest scripts`
- `git diff --check`

## 참고 사항
- Windows 환경에서 `sh`가 PATH에 없는 경우가 있어 `.sh` wrapper 직접 호출 대신 `python3` 기준으로 최소 변경했습니다.