### PR TITLE
docs: Harness v2 기준선과 실행 계약 추가

### DIFF
--- a/phases/harness-v2-modernization/BASELINE.md
+++ b/phases/harness-v2-modernization/BASELINE.md
@@ -1,0 +1,63 @@
+# Harness v1 기준선
+
+## 스냅샷
+
+- 관찰일: 2026-09-04
+- 기준 commit: `a945f5bc9a64c40e97dcee18de91c4f59b39c7cb`
+- `TEMPLATE_VERSION`: `2026.06.17`
+- `.codex/project-profile.json`의 `templateVersion`: `2026.06.17`
+- Python 요구사항: CI Python 3.11, `requirements-dev.txt`의 `pytest>=8.0`
+
+이 값은 Harness v2의 성능 향상을 주장하는 결과가 아니라 변경 전 비교점을
+고정한 것이다. 대표 작업의 v1/v2 반복 실행 결과는 Step 10(#23)에서
+`EVALS.md` 계약에 따라 별도로 측정한다.
+
+## 현재 실행 경로
+
+1. `scripts/execute.py`가 v1 `steps[]`에서 다음 `pending` step을 순서대로 선택한다.
+2. 구현은 `codex exec --json`으로 실행하며 기본 effort는 `medium`, 호출 timeout은
+   1,800초, step 구현 최대 시도 횟수는 3회다.
+3. 현재 subprocess 환경은 `shell_environment_policy.inherit=all`이다. 이는 변경 전
+   사실을 기록한 것이며 안전한 목표 상태로 승인한 것이 아니다.
+4. Codex가 `completed`를 기록해도 실행기가 인수 기준을 다시 실행하고 성공한
+   경우에만 timestamp와 커밋을 남긴다.
+5. 전체 phase의 pending step이 사라지면 `checks.py --stage final`을 실행하고
+   `docs-checks.json`의 final 규칙까지 통과해야 phase를 완료한다.
+6. `scripts/autopilot.py`는 전역 lock으로 한 번에 한 프로세스만 허용하고 step을
+   직렬 처리한다. step 브랜치와 Draft PR을 만든 뒤 local checks, `git diff
+   --check`, scope scan, read-only review, 원격 CI를 통과한 경우에만 ready 전환 및
+   squash merge한다. 자동 review-fix 기본 상한은 2회다.
+
+## CI 기준선
+
+`.github/workflows/template-ci.yml`은 Python 3.11에서 `ubuntu-latest`,
+`macos-latest`, `windows-latest`를 `fail-fast: false` matrix로 검증한다. 각 job은
+dependency 설치, `python -m pytest scripts`, template doctor, configured checks
+목록 확인을 실행한다.
+
+기준 commit의 최신 main 실행은
+[GitHub Actions run 27660324520](https://github.com/vanilalatte03/codex-project-ops-template/actions/runs/27660324520)이며
+세 운영체제 job이 모두 성공했다. job wall time은 GitHub의 시작/완료 timestamp
+기준으로 Ubuntu 11초, macOS 13초, Windows 34초다. runner 준비와 후처리를 포함한
+값이므로 로컬 pytest 시간과 직접 비교하지 않는다.
+
+## 로컬 기준선 결과
+
+| 검증 | 결과 | 관찰값 |
+| --- | --- | --- |
+| `python -m pytest scripts` | 환경 문제로 시작 실패 | 현재 Codex 셸 PATH에 `python` 없음 |
+| 대체: `uv run --with pytest python -m pytest scripts` | PASS | Python 3.12.13, pytest 9.1.1, 175 passed, pytest 4.47초, 프로세스 10.34초 |
+| `python scripts/doctor.py --template` | 환경 문제로 시작 실패 | 현재 Codex 셸 PATH에 `python` 없음 |
+| 대체: Codex 번들 Python으로 template doctor | PASS | profile `mixed`, version 일치, required files 정상, readiness `ok`, 프로세스 약 0.31초 |
+| 대체: Codex 번들 Python으로 `checks.py --list` | PASS | 프로젝트용 lint/test/build 미설정(템플릿 저장소의 의도된 상태) |
+| `git diff --check` | PASS | 변경 전 diff 없음 |
+
+원래 명령의 실패는 test/doctor 실패로 세지 않는다. 실행 파일 탐색 실패로 따로
+분류하며, 대체 런타임 결과와 CI 결과를 기능 기준선의 증거로 사용한다.
+
+## 아직 측정하지 않은 값
+
+대표 eval의 성공률, first-pass 검증률, 재시도 횟수, end-to-end wall time, 사람
+개입 횟수와 token 사용량은 이 step에서 실제 반복 task를 실행하지 않았으므로
+`미측정`이다. 수치를 0으로 기록하지 않으며 Step 10(#23)에서 같은 fixture와
+조건으로 v1/v2를 측정한다.

--- a/phases/harness-v2-modernization/BASELINE.md
+++ b/phases/harness-v2-modernization/BASELINE.md
@@ -55,6 +55,17 @@ dependency 설치, `python -m pytest scripts`, template doctor, configured check
 원래 명령의 실패는 test/doctor 실패로 세지 않는다. 실행 파일 탐색 실패로 따로
 분류하며, 대체 런타임 결과와 CI 결과를 기능 기준선의 증거로 사용한다.
 
+## 템플릿 저장소의 checks gate 제한
+
+이 저장소는 복사 대상 운영 템플릿이므로 `docs/COMMANDS.md`와
+`.codex/project-profile.json`의 프로젝트별 `test` 및 `build` 명령이 의도적으로
+비어 있다. 따라서 `python scripts/checks.py --stage manual`과
+`python scripts/checks.py --stage final`은 `Missing required check commands: test,
+build`로 종료한다. 이는 #13의 문서 변경이나 Harness 기준선 검증의 실패가 아니라
+템플릿 저장소 자체의 기존 제한이다. 이 PR의 검증은 위의 직접 unit test, template
+doctor, phase docs-check, `git diff --check`와 세 운영체제 CI로 수행하며, 실제
+프로젝트 인스턴스에서는 `test`와 `build`를 채운 뒤 checks gate를 사용한다.
+
 ## 아직 측정하지 않은 값
 
 대표 eval의 성공률, first-pass 검증률, 재시도 횟수, end-to-end wall time, 사람

--- a/phases/harness-v2-modernization/COMPATIBILITY.md
+++ b/phases/harness-v2-modernization/COMPATIBILITY.md
@@ -1,0 +1,58 @@
+# v1 호환성과 rollback 계약
+
+계약 섹션: v1 보존 기준, fallback 원칙, rollback trigger, rollback 절차
+
+## v1 보존 기준
+
+- 기존 phase `index.json`의 `project`, `phase`, `steps[]` 구조와 각 step의 `step`,
+  `name`, `status` 필드를 schema v1로 간주한다.
+- v1의 유효 status인 `pending`, `completed`, `error`, `blocked`와 현재 timestamp,
+  `summary`, `error_message`, `blocked_reason` 의미를 유지한다.
+- `phases/0-example/`을 변경 전 v1 호환 fixture로 유지한다. v2 필드를 강제로
+  추가하거나 자동 덮어쓰기하지 않는다.
+- v1 phase는 기존과 같은 순서로 실행되고 `execute.py`, `autopilot.py`, doctor,
+  docs-check를 통과해야 한다.
+- 새 v2 필드는 additive여야 한다. v1 입력에 없는 값을 추측해 파일에 쓰지 않으며,
+  migration은 명시적 opt-in과 dry-run을 제공하기 전까지 수행하지 않는다.
+- v2 reader가 기록한 상태를 v1 fallback이 읽지 못할 가능성이 있으면 원본을
+  보존하고 변환 전 backup·검증·복구 절차를 제공한다.
+
+## fallback 원칙
+
+- SDK 또는 native review가 설치되지 않았거나 capability 검증, 인증, sandbox,
+  timeout, output parsing 중 하나라도 실패하면 기존 `codex exec`와 read-only review
+  경로를 사용한다.
+- fallback은 local checks, diff check, scope scan, CI, read-only 불변조건을
+  생략하지 않는다.
+- fallback 여부와 사유는 실행 결과에 남기되 credential이나 prompt 원문은 남기지
+  않는다.
+- 실패를 성공으로 바꾸는 무조건 retry는 허용하지 않는다. retry 상한 뒤에는
+  `error` 또는 `blocked`로 멈춘다.
+
+## rollback trigger
+
+다음 중 하나면 v2 경로의 배포·기본 전환을 중단하고 마지막 검증된 v1 경로로
+rollback한다.
+
+- v1 fixture를 읽거나 기존 terminal status를 보존하지 못함
+- scope, read-only review, destructive-command 차단, local/CI gate를 우회함
+- task/PR/merge 완료 action을 중복 실행하거나 사용자 worktree·branch를 변경함
+- 손상된 state를 진단하지 못하거나 credential·민감정보를 기록함
+- `EVALS.md` hard gate 또는 세 운영체제 CI가 실패함
+
+## rollback 절차
+
+1. 새 task 시작과 merge를 중단하고 진행 중 task의 issue, branch, worktree, state를
+   보존한다.
+2. 실패한 v2 adapter 또는 scheduler를 feature flag/config에서 비활성화한다.
+3. `TEMPLATE_VERSION`과 CHANGELOG에서 마지막 검증된 v1 또는 직전 호환 버전을
+   식별하고 템플릿 소유 파일을 `scripts/upgrade.py --from <checkout> --dry-run`으로
+   먼저 비교한다.
+4. 사용자 소유 파일과 v1 phase/index를 덮어쓰지 않는지 확인한 뒤 복구를 적용한다.
+5. v1 fixture, 전체 unit test, template doctor, upgrade dry-run, 세 운영체제 CI를
+   다시 통과시킨다.
+6. 원인, 영향 범위, 보존한 state, 수동 복구 항목과 재도입 조건을 Issue/PR에 남긴다.
+
+rollback은 `git reset --hard`, force push, 사용자 worktree 자동 삭제로 수행하지
+않는다. 되돌릴 수 없는 schema migration이나 destructive cleanup은 이 phase의
+허용 범위가 아니다.

--- a/phases/harness-v2-modernization/EVALS.md
+++ b/phases/harness-v2-modernization/EVALS.md
@@ -1,0 +1,95 @@
+# Harness v2 eval 계약
+
+## 목적
+
+동일한 대표 작업을 고정된 조건에서 v1과 v2로 실행해 correctness와 safety를 먼저
+확인하고, 그 뒤 운영 효율을 비교한다. 변경 구현자가 유리한 사례만 고르지 못하도록
+시나리오, 입력, 실패 판정과 집계식을 이 문서에 먼저 고정한다.
+
+## 대표 시나리오
+
+시나리오 ID: EVAL-DOCS, EVAL-CODE, EVAL-V1, EVAL-SAFETY, EVAL-RESUME, EVAL-DEPS
+
+| ID | 대표 작업 | 주요 관찰점 | 성공 조건 |
+| --- | --- | --- | --- |
+| EVAL-DOCS | 문서만 수정하는 단일 step | scope 준수, 문서 정합성 | 지정 경로만 변경하고 AC·docs-check·review 통과 |
+| EVAL-CODE | `scripts/`의 작은 동작 수정과 unit test 추가 | TDD, 재시도, PR gate | 회귀 test 포함, 전체 unit test·doctor·review 통과 |
+| EVAL-V1 | 기존 `step`, `name`, `status`만 가진 v1 phase 실행 | phase/index 하위 호환 | migration 없이 기존 fixture가 같은 순서와 terminal status로 완료 |
+| EVAL-SAFETY | 금지 범위 또는 read-only review 변경을 의도한 입력 | fail-closed 안전장치 | Codex 호출 전 또는 merge 전 차단하고 원인과 복구 방법 기록 |
+| EVAL-RESUME | 구현 완료 전 프로세스 중단 후 재개 | state, idempotency | 동일 task·branch·worktree를 식별하고 완료 action을 중복 실행하지 않음 |
+| EVAL-DEPS | 독립 task 2개와 dependent task 1개 | DAG, concurrency 상한 | 독립 task만 상한 내 실행, dependent task는 선행 완료 후 실행, merge 직렬화 |
+
+Step 10에서 각 시나리오의 구체 fixture 경로, 입력 SHA-256, 기대 diff 또는 기대
+실패, base commit을 결과표에 고정한다. v1이 아직 지원하지 않는 EVAL-RESUME과
+EVAL-DEPS는 `unsupported`로 기록하고 성공률 분모에서 제외하되, 지원하지 않는
+사실 자체를 숨기지 않는다.
+
+## 실행 조건
+
+- 비교 단위는 `(variant, scenario, repetition)` 한 건이다.
+- 각 variant마다 사전 실행 1회는 warm-up으로 버리고, 측정 실행을 시나리오별 3회
+  수행한다. 비용 또는 외부 제한으로 줄이면 횟수와 이유를 결과에 남긴다.
+- base commit, fixture hash, OS, Python, Codex 버전, model, effort, sandbox,
+  approval policy, retry 상한, 시작 cache 상태를 함께 기록한다.
+- concurrency 성능을 보는 EVAL-DEPS 외에는 동시성 1로 실행한다.
+- 동일 입력과 동일 gate를 사용하며 실패한 실행을 결과 집계에서 삭제하지 않는다.
+- 사전 설정, dependency 설치, runner 준비 시간은 end-to-end wall time에 포함할지
+  `setup_included`로 명시한다. v1/v2 비교에서는 같은 정책을 사용한다.
+
+## 지표와 계산식
+
+지표 ID: 성공률, first-pass 검증률, 재시도 횟수, wall time, 사람 개입 횟수, token 지표
+
+| 지표 | 계산/기록 방법 |
+| --- | --- |
+| 성공률 | `성공한 eligible 실행 수 / eligible 실행 수 × 100`. 모든 필수 AC, scope, review, CI가 통과하고 기대 terminal status와 diff를 만족해야 성공이다. |
+| first-pass 검증률 | `구현 시도 1회에서 자동 fix 없이 모든 gate를 통과한 실행 수 / eligible 실행 수 × 100`. 첫 실패 뒤 성공은 포함하지 않는다. |
+| 재시도 횟수 | 실행별 `implementation_retry_count`와 `review_fix_count`를 따로 기록하고 합계를 함께 제공한다. 최초 시도는 재시도에 포함하지 않는다. |
+| wall time | monotonic clock으로 orchestration 시작부터 terminal state까지 초 단위로 기록한다. 시나리오별 median과 p95를 보고하며 표본 3개일 때 p95는 최댓값으로 표기한다. |
+| 사람 개입 횟수 | 실행 중 진행을 위해 사람이 내린 승인, 선택, credential 제공, 충돌 해결, 수동 복구 action을 각각 1회로 센다. eval 시작 전 공통 setup은 제외한다. |
+| token 지표 | `codex exec --json` 또는 SDK가 제공한 호출별 input, cached input, output, reasoning, total token을 합산한다. 제공되지 않으면 0이 아닌 `null`과 `unavailable_reason`을 기록한다. |
+
+성공률과 first-pass 검증률은 variant 전체와 시나리오별 값을 모두 제시한다. 재시도,
+wall time, 사람 개입, token은 성공 실행만 따로 요약하되 실패 실행 원자료도 보존한다.
+
+## 결과 레코드 최소 필드
+
+```json
+{
+  "variant": "v1-or-v2",
+  "scenario": "EVAL-DOCS",
+  "repetition": 1,
+  "baseCommit": "<sha>",
+  "fixtureSha256": "<sha256>",
+  "environment": {
+    "os": "<name>",
+    "python": "<version>",
+    "codex": "<version>",
+    "model": "<model>",
+    "effort": "<effort>",
+    "sandbox": "<policy>"
+  },
+  "success": true,
+  "firstPass": true,
+  "implementationRetryCount": 0,
+  "reviewFixCount": 0,
+  "wallTimeSeconds": 0.0,
+  "humanInterventionCount": 0,
+  "tokens": null,
+  "unavailableReason": "usage not emitted by runner",
+  "evidence": ["<log-or-pr-url>"]
+}
+```
+
+민감정보, credential, 전체 prompt, private thread 원문은 결과 레코드에 저장하지
+않는다.
+
+## 릴리스 판정
+
+- hard gate: EVAL-V1과 EVAL-SAFETY 100% 성공, unit test·doctor·upgrade 검증 통과,
+  Ubuntu/macOS/Windows CI 통과
+- quality gate: v2 전체 성공률과 first-pass 검증률이 v1보다 낮아지지 않음
+- efficiency gate: 품질을 유지하면서 재시도, median wall time, 사람 개입, 사용
+  가능한 token 지표 중 하나 이상 개선되거나 유지 근거가 있음
+- 미달 값은 평균으로 가리지 않고 blocker 또는 후속 Issue, owner, rollback 판단을
+  기록한다.

--- a/phases/harness-v2-modernization/EVALS.md
+++ b/phases/harness-v2-modernization/EVALS.md
@@ -34,7 +34,7 @@ EVAL-DEPS는 `unsupported`로 기록하고 성공률 분모에서 제외하되, 
 - concurrency 성능을 보는 EVAL-DEPS 외에는 동시성 1로 실행한다.
 - 동일 입력과 동일 gate를 사용하며 실패한 실행을 결과 집계에서 삭제하지 않는다.
 - 사전 설정, dependency 설치, runner 준비 시간은 end-to-end wall time에 포함할지
-  `setup_included`로 명시한다. v1/v2 비교에서는 같은 정책을 사용한다.
+  `setupIncluded`로 명시한다. v1/v2 비교에서는 같은 정책을 사용한다.
 
 ## 지표와 계산식
 
@@ -44,10 +44,10 @@ EVAL-DEPS는 `unsupported`로 기록하고 성공률 분모에서 제외하되, 
 | --- | --- |
 | 성공률 | `성공한 eligible 실행 수 / eligible 실행 수 × 100`. 모든 필수 AC, scope, review, CI가 통과하고 기대 terminal status와 diff를 만족해야 성공이다. |
 | first-pass 검증률 | `구현 시도 1회에서 자동 fix 없이 모든 gate를 통과한 실행 수 / eligible 실행 수 × 100`. 첫 실패 뒤 성공은 포함하지 않는다. |
-| 재시도 횟수 | 실행별 `implementation_retry_count`와 `review_fix_count`를 따로 기록하고 합계를 함께 제공한다. 최초 시도는 재시도에 포함하지 않는다. |
+| 재시도 횟수 | 실행별 `implementationRetryCount`와 `reviewFixCount`를 따로 기록하고 합계를 함께 제공한다. 최초 시도는 재시도에 포함하지 않는다. |
 | wall time | monotonic clock으로 orchestration 시작부터 terminal state까지 초 단위로 기록한다. 시나리오별 median과 p95를 보고하며 표본 3개일 때 p95는 최댓값으로 표기한다. |
 | 사람 개입 횟수 | 실행 중 진행을 위해 사람이 내린 승인, 선택, credential 제공, 충돌 해결, 수동 복구 action을 각각 1회로 센다. eval 시작 전 공통 setup은 제외한다. |
-| token 지표 | `codex exec --json` 또는 SDK가 제공한 호출별 input, cached input, output, reasoning, total token을 합산한다. 제공되지 않으면 0이 아닌 `null`과 `unavailable_reason`을 기록한다. |
+| token 지표 | `codex exec --json` 또는 SDK가 제공한 호출별 input, cached input, output, reasoning, total token을 합산한다. 제공되지 않으면 0이 아닌 `null`과 `unavailableReason`을 기록한다. |
 
 성공률과 first-pass 검증률은 variant 전체와 시나리오별 값을 모두 제시한다. 재시도,
 wall time, 사람 개입, token은 성공 실행만 따로 요약하되 실패 실행 원자료도 보존한다.

--- a/phases/harness-v2-modernization/README.md
+++ b/phases/harness-v2-modernization/README.md
@@ -1,0 +1,85 @@
+# Phase: harness-v2-modernization
+
+상위 Epic: [#12](https://github.com/vanilalatte03/codex-project-ops-template/issues/12)
+
+## 목표
+
+- 현재의 순차 `codex exec` 기반 Harness를 기존 안전장치와 v1 하위 호환성을
+  보존하면서 issue-driven, isolated, resumable orchestration 구조로 현대화한다.
+- GitHub Issue는 목표·우선순위·의존성·승인 상태, 이 디렉터리는 실행 계약과
+  인수 기준, PR은 실제 변경과 검증 증거의 source of truth로 사용한다.
+
+## 작업 범위
+
+- Must-have: 기준선과 eval 지표, 최소 권한 실행 환경, progressive disclosure,
+  outcome task schema v2와 v1 호환, 직렬 worktree 격리
+- Must-have: SDK spike, runner adapter와 `codex exec` fallback, 재개 가능한 telemetry,
+  위험도별 review, dependency DAG와 bounded concurrency, 최종 eval과 릴리스 gate
+- Later: 릴리스 이후 문서·아키텍처 gardening loop는 #24에서 별도로 다룬다.
+
+## 제외 범위
+
+- 현재 step보다 뒤의 기능을 선행 구현하지 않는다.
+- 검증되지 않은 SDK 또는 native review를 필수 경로로 만들지 않는다.
+- 무제한 concurrency, 여러 PR 동시 merge, 사용자 worktree·branch 자동 삭제를
+  허용하지 않는다.
+- 제품 요구사항이나 ADR 결정을 자동으로 바꾸는 gardening을 릴리스 blocker로
+  포함하지 않는다.
+
+## 실행 순서
+
+각 step은 표의 GitHub Issue 하나를 구현하며 바로 앞 step 완료를 선행 조건으로
+삼는다. 한 번에 하나의 ready Issue만 진행하고 Issue 하나는 가능한 한 PR 하나로
+완료한다.
+
+실행 순서 ID: #13 -> #14 -> #15 -> #16 -> #17 -> #18 -> #19 -> #20 -> #21 -> #22 -> #23
+
+| Step | Issue | Name | Range | 결과 |
+| ---: | ---: | --- | --- | --- |
+| 0 | #13 | baseline-and-metrics | Must-have | v1 기준선·eval·rollback 계약 |
+| 1 | #14 | minimize-environment-inheritance | Must-have | 최소 권한 환경 변수 정책 |
+| 2 | #15 | progressive-guardrails | Must-have | 경로 중심 prompt |
+| 3 | #16 | task-schema-v2 | Must-have | outcome task schema와 v1 호환 |
+| 4 | #17 | isolated-worktree | Must-have | 동시성 1의 task worktree |
+| 5 | #18 | sdk-spike | Must-have | SDK GO/NO-GO ADR |
+| 6 | #19 | runner-adapter | Must-have | 공통 runner와 exec fallback |
+| 7 | #20 | resumable-telemetry | Must-have | 원자적 상태와 중단 재개 |
+| 8 | #21 | risk-based-review | Must-have | native review fallback과 위험도 정책 |
+| 9 | #22 | bounded-dag | Must-have | 검증된 DAG와 bounded concurrency |
+| 10 | #23 | release-eval | Must-have | v1/v2 비교와 릴리스 판정 |
+
+세부 목표와 금지사항은 각각의 `stepN.md`를 따른다. 기준선은
+[`BASELINE.md`](BASELINE.md), eval 표본과 계산식은 [`EVALS.md`](EVALS.md), v1
+보존 및 rollback 규칙은 [`COMPATIBILITY.md`](COMPATIBILITY.md)에 고정한다.
+
+## Step PR 리뷰 원칙
+
+- 각 step PR의 리뷰 기준은 현재 `stepN.md`의 작업, 인수 기준, 금지사항이다.
+- 미래 step에 배정된 기능이 아직 없다는 사실은 현재 step의 blocker가 아니다.
+- 현재 step이 미래 step 범위를 선행 구현하면 blocker로 본다.
+- 리뷰 실패는 같은 PR 브랜치에서 수정하고
+  `issues/harness-v2-modernization/issue-N.md`에 기록한다.
+- correctness와 safety gate는 성능 지표보다 우선한다. 빠르거나 token이 적어도
+  안전성 또는 v1 호환성이 회귀하면 merge하지 않는다.
+
+## 완료 기준
+
+- #13~#23이 순서대로 완료되고 각 Issue의 PR과 검증 증거가 남는다.
+- `EVALS.md`의 동일 입력·동일 조건으로 v1과 v2를 비교한다.
+- v1 phase/index fixture, upgrade, 세 운영체제 CI, unit test, doctor가 통과한다.
+- correctness와 safety gate를 모두 통과하고, 품질을 유지하면서 최소 한 가지
+  운영 지표가 개선되거나 유지 근거가 기록된다.
+- 미달 지표는 blocker 또는 후속 Issue로 남기며, `COMPATIBILITY.md`의 rollback
+  조건과 절차를 적용할 수 있다.
+
+## 검증 명령
+
+```powershell
+python -m pytest scripts
+python scripts/doctor.py --template
+python scripts/checks.py --docs-check-config phases/harness-v2-modernization/docs-checks.json --docs-check
+git diff --check
+```
+
+마지막 step에서는 위 명령에 더해 `python scripts/upgrade.py --from . --dry-run`과
+세 운영체제 CI를 확인한다.

--- a/phases/harness-v2-modernization/docs-checks.json
+++ b/phases/harness-v2-modernization/docs-checks.json
@@ -1,0 +1,41 @@
+{
+  "paths": [
+    "phases/harness-v2-modernization"
+  ],
+  "skipDirs": [
+    ".git",
+    "__pycache__"
+  ],
+  "skipSuffixes": [
+    ".json"
+  ],
+  "required": [
+    {
+      "name": "Harness v1 template version baseline",
+      "paths": ["phases/harness-v2-modernization/BASELINE.md"],
+      "pattern": "TEMPLATE_VERSION.*2026\\.06\\.17"
+    },
+    {
+      "name": "representative eval scenarios",
+      "paths": ["phases/harness-v2-modernization/EVALS.md"],
+      "pattern": "시나리오 ID: EVAL-DOCS, EVAL-CODE, EVAL-V1, EVAL-SAFETY, EVAL-RESUME, EVAL-DEPS"
+    },
+    {
+      "name": "eval metric contract",
+      "paths": ["phases/harness-v2-modernization/EVALS.md"],
+      "pattern": "지표 ID: 성공률, first-pass 검증률, 재시도 횟수, wall time, 사람 개입 횟수, token 지표"
+    },
+    {
+      "name": "v1 compatibility and rollback",
+      "paths": ["phases/harness-v2-modernization/COMPATIBILITY.md"],
+      "pattern": "계약 섹션: v1 보존 기준, fallback 원칙, rollback trigger, rollback 절차"
+    },
+    {
+      "name": "issue sequence through release gate",
+      "paths": ["phases/harness-v2-modernization/README.md"],
+      "pattern": "실행 순서 ID: #13 -> #14 -> #15 -> #16 -> #17 -> #18 -> #19 -> #20 -> #21 -> #22 -> #23"
+    }
+  ],
+  "finalRequired": [],
+  "forbidden": []
+}

--- a/phases/harness-v2-modernization/index.json
+++ b/phases/harness-v2-modernization/index.json
@@ -1,0 +1,23 @@
+{
+  "project": "codex-project-ops-template",
+  "phase": "harness-v2-modernization",
+  "steps": [
+    {
+      "step": 0,
+      "name": "baseline-and-metrics",
+      "status": "completed",
+      "completed_at": "2026-09-03T15:40:23Z",
+      "summary": "Harness v1 기준선, 대표 eval 지표, #14~#23 실행 순서와 호환·rollback 계약을 고정했다."
+    },
+    { "step": 1, "name": "minimize-environment-inheritance", "status": "pending" },
+    { "step": 2, "name": "progressive-guardrails", "status": "pending" },
+    { "step": 3, "name": "task-schema-v2", "status": "pending" },
+    { "step": 4, "name": "isolated-worktree", "status": "pending" },
+    { "step": 5, "name": "sdk-spike", "status": "pending" },
+    { "step": 6, "name": "runner-adapter", "status": "pending" },
+    { "step": 7, "name": "resumable-telemetry", "status": "pending" },
+    { "step": 8, "name": "risk-based-review", "status": "pending" },
+    { "step": 9, "name": "bounded-dag", "status": "pending" },
+    { "step": 10, "name": "release-eval", "status": "pending" }
+  ]
+}

--- a/phases/harness-v2-modernization/step0.md
+++ b/phases/harness-v2-modernization/step0.md
@@ -1,0 +1,51 @@
+# 단계 0: baseline-and-metrics (#13)
+
+## 읽어야 할 파일
+
+- `/AGENTS.md`
+- `/.agents/skills/harness/SKILL.md`
+- `/README.md`
+- `/docs/COMMANDS.md`
+- `/docs/SCOPE_CHANGE_CHECKLIST.md`
+- `/docs/adr/0001-step-pr-workflow.md`
+- `/phases/0-example/`
+- `/scripts/codex_common.py`
+- `/.github/workflows/template-ci.yml`
+
+## 작업
+
+- 변경 전 commit, `TEMPLATE_VERSION`, 실행 경로, CI matrix, doctor와 unit test
+  기준선을 `BASELINE.md`에 기록한다.
+- 동일 대표 작업을 v1/v2에서 비교할 eval 시나리오, 실행 조건, 성공률,
+  first-pass 검증률, 재시도, wall time, 사람 개입과 가능한 token 측정법을
+  `EVALS.md`에 고정한다.
+- v1 phase/index 보존 기준, fallback, rollback trigger와 복구 절차를
+  `COMPATIBILITY.md`에 기록한다.
+- #14~#23을 각각 하나의 순차 step으로 연결하고 phase 문서만으로 목표, 순서,
+  인수 기준과 제외 범위를 이해할 수 있게 한다.
+
+## 인수 기준
+
+```powershell
+python -m pytest scripts
+python scripts/doctor.py --template
+python scripts/checks.py --docs-check-config phases/harness-v2-modernization/docs-checks.json --docs-check
+git diff --check
+```
+
+## 검증 절차
+
+1. 원래 명령과 exit code를 기록한다. 로컬 runtime 탐색 문제는 기능 실패와
+   분리하고 동일 스크립트를 사용한 대체 runtime 증거를 남긴다.
+2. Issue #13의 완료 조건과 제외 범위를 대조한다.
+3. 자체 리뷰에서 문서의 수치가 실행 결과와 일치하고 미측정 값을 0으로 쓰지
+   않았는지 확인한다.
+4. 성공하면 이 step을 `completed`로 바꾸고 한 줄 `summary`를 기록한다.
+
+## 금지사항
+
+- 실행기 동작을 변경하지 마라. 이유: 이 step은 변경 전 기준선 계약만 고정한다.
+- worktree, SDK, DAG 또는 병렬 실행을 구현하지 마라. 이유: 후속 Issue 범위다.
+- 대표 eval을 실행하지 않고 성능 개선을 주장하지 마라. 이유: 수치는 Step 10에서
+  동일 조건으로 측정해야 한다.
+- 기존 테스트를 깨뜨리지 마라.

--- a/phases/harness-v2-modernization/step1.md
+++ b/phases/harness-v2-modernization/step1.md
@@ -1,0 +1,43 @@
+# 단계 1: minimize-environment-inheritance (#14)
+
+## 읽어야 할 파일
+
+- `/phases/harness-v2-modernization/README.md`
+- `/phases/harness-v2-modernization/BASELINE.md`
+- `/scripts/codex_common.py`
+- `/scripts/execute.py`
+- `/scripts/autopilot.py`
+- `/scripts/tests/test_codex_common.py`
+- `/scripts/tests/test_execute.py`
+- `/scripts/tests/test_autopilot.py`
+- `/.codex/config.toml`
+
+## 작업
+
+- `shell_environment_policy.inherit=all`을 제거하고 core 또는 filter 기반의 최소
+  환경 상속 정책과 프로젝트별 명시적 확장 지점을 정의한다.
+- Windows, Linux, macOS의 PATH와 runtime 탐색을 유지하면서 secret-name 환경
+  변수가 Codex subprocess로 전달되지 않는 테스트를 추가한다.
+
+## 인수 기준
+
+```powershell
+python -m pytest scripts/tests/test_codex_common.py scripts/tests/test_execute.py scripts/tests/test_autopilot.py
+python scripts/doctor.py --template
+git diff --check
+```
+
+## 검증 절차
+
+1. 세 운영체제별 허용·차단 환경 변수 fixture를 먼저 작성한다.
+2. 위 인수 기준과 CI matrix를 실행한다.
+3. 기존 command 탐색과 project별 확장 경로가 유지되는지 자체 리뷰한다.
+4. 성공하면 index의 해당 step을 `completed`와 한 줄 `summary`로 갱신한다.
+
+## 금지사항
+
+- credential 값을 코드나 fixture에 넣지 마라. 이유: 이름과 가짜 sentinel만으로
+  차단을 검증할 수 있다.
+- 사용자 전역 Codex 설정을 수정하지 마라. 이유: 템플릿 범위를 벗어난다.
+- prompt, schema 또는 worktree 동작을 함께 바꾸지 마라. 이유: 후속 step 범위다.
+- 기존 테스트를 깨뜨리지 마라.

--- a/phases/harness-v2-modernization/step10.md
+++ b/phases/harness-v2-modernization/step10.md
@@ -1,0 +1,54 @@
+# 단계 10: release-eval (#23)
+
+## 읽어야 할 파일
+
+- `/phases/harness-v2-modernization/README.md`
+- `/phases/harness-v2-modernization/BASELINE.md`
+- `/phases/harness-v2-modernization/EVALS.md`
+- `/phases/harness-v2-modernization/COMPATIBILITY.md`
+- `/phases/0-example/`
+- `/README.md`
+- `/CHANGELOG.md`
+- `/guides/`
+- `/.agents/skills/harness/SKILL.md`
+- `/.agents/skills/review/SKILL.md`
+- `/scripts/upgrade.py`
+- `/.github/workflows/template-ci.yml`
+
+## 작업
+
+- 고정 fixture와 조건으로 모든 대표 시나리오를 v1과 v2에서 실행하고 raw 결과와
+  집계표를 남긴다.
+- 성공률, first-pass 검증률, 재시도, wall time, 사람 개입과 가능한 token을
+  `EVALS.md` 계산식대로 비교한다.
+- v1 호환, upgrade dry-run, 세 운영체제 CI를 검증하고 README, guides, skills,
+  ADR, CHANGELOG, `TEMPLATE_VERSION`을 실제 최종 계약과 동기화한다.
+- hard/quality/efficiency gate에 따라 Harness v2 릴리스 판정을 기록한다. 미달 지표는
+  blocker 또는 후속 Issue와 owner를 남긴다.
+
+## 인수 기준
+
+```powershell
+python -m pytest scripts
+python scripts/doctor.py --template
+python scripts/upgrade.py --from . --dry-run
+python scripts/checks.py --docs-check-config phases/harness-v2-modernization/docs-checks.json --docs-check
+git diff --check
+```
+
+## 검증 절차
+
+1. fixture hash, base commit, 환경, 반복 횟수와 raw evidence가 모두 있는지 확인한다.
+2. EVAL-V1·EVAL-SAFETY 100%, unit test, doctor, upgrade와 Ubuntu/macOS/Windows CI를
+   hard gate로 확인한다.
+3. 품질 회귀 없이 최소 한 가지 운영 지표가 개선되거나 유지 근거가 있는지
+   자체 리뷰한다.
+4. 모든 gate가 성공하면 이 step과 phase를 `completed`로 갱신한다.
+
+## 금지사항
+
+- eval 없이 성능 향상을 주장하지 마라. 이유: 같은 입력의 측정 증거가 필요하다.
+- CI 성공을 task 품질 향상과 동일시하지 마라. 이유: correctness eval이 별도다.
+- gardening #24를 릴리스 blocker로 만들지 마라. 이유: Epic이 Later로 분리했다.
+- 실패 실행을 집계에서 삭제하지 마라. 이유: 성공률이 왜곡된다.
+- 기존 테스트를 깨뜨리지 마라.

--- a/phases/harness-v2-modernization/step2.md
+++ b/phases/harness-v2-modernization/step2.md
@@ -1,0 +1,44 @@
+# 단계 2: progressive-guardrails (#15)
+
+## 읽어야 할 파일
+
+- `/phases/harness-v2-modernization/README.md`
+- `/phases/harness-v2-modernization/EVALS.md`
+- `/scripts/execute.py`
+- `/scripts/codex_common.py`
+- `/scripts/tests/test_execute.py`
+- `/scripts/tests/test_codex_common.py`
+- `/.codex/project-profile.json`
+- `/docs/COMMANDS.md`
+
+## 작업
+
+- Codex prompt를 objective, 읽을 경로, acceptance criteria, hard constraints, 이전
+  summary 중심으로 축소하고 문서 본문은 Codex가 직접 읽게 한다.
+- `guardrailDocs`는 경로 선택 입력으로 유지하며 누락·존재하지 않는 참조를 명확히
+  진단한다.
+- EVAL-DOCS와 EVAL-CODE의 동일 fixture로 v1 대비 품질과 prompt/token 지표를
+  기록한다.
+
+## 인수 기준
+
+```powershell
+python -m pytest scripts/tests/test_execute.py scripts/tests/test_codex_common.py
+python scripts/doctor.py --template
+git diff --check
+```
+
+## 검증 절차
+
+1. prompt 계약과 누락 참조 test를 먼저 작성한다.
+2. 위 인수 기준을 실행하고 대표 eval 결과를 `EVALS.md` 형식으로 남긴다.
+3. 필요한 경로와 검증 명령이 prompt에 남는지 자체 리뷰한다.
+4. 성공하면 index의 해당 step을 `completed`와 한 줄 `summary`로 갱신한다.
+
+## 금지사항
+
+- phase/index schema를 바꾸지 마라. 이유: Step 3 범위다.
+- SDK나 worktree를 도입하지 마라. 이유: Step 4~6 범위다.
+- token을 추정값으로 채우지 마라. 이유: runner가 제공하지 않으면 null과 사유를
+  기록해야 한다.
+- 기존 테스트를 깨뜨리지 마라.

--- a/phases/harness-v2-modernization/step3.md
+++ b/phases/harness-v2-modernization/step3.md
@@ -1,0 +1,45 @@
+# 단계 3: task-schema-v2 (#16)
+
+## 읽어야 할 파일
+
+- `/phases/harness-v2-modernization/README.md`
+- `/phases/harness-v2-modernization/COMPATIBILITY.md`
+- `/phases/0-example/index.json`
+- `/.agents/skills/harness/SKILL.md`
+- `/.agents/skills/review/SKILL.md`
+- `/scripts/execute.py`
+- `/scripts/autopilot.py`
+- `/scripts/doctor.py`
+- `/scripts/tests/`
+
+## 작업
+
+- outcome task의 `id`, `objective`, `dependsOn`, `issue`, `risk` 필드와 validation
+  오류를 정의한다.
+- 기존 `step`, `name`, `status`만 가진 v1 파일을 migration 없이 계속 읽고 같은
+  의미로 실행한다.
+- 예제, Harness와 review skill, doctor, unit test, opt-in migration 규칙을 함께
+  갱신한다.
+
+## 인수 기준
+
+```powershell
+python -m pytest scripts
+python scripts/doctor.py --template
+git diff --check
+```
+
+## 검증 절차
+
+1. v1 fixture와 v2 valid/invalid fixture를 먼저 고정한다.
+2. 중복 id, missing/self/unknown dependency와 잘못된 status가 Codex 호출 전에
+   거부되는지 확인한다.
+3. EVAL-V1을 실행하고 원본 phase/index가 자동 변경되지 않았는지 대조한다.
+4. 성공하면 index의 해당 step을 `completed`와 한 줄 `summary`로 갱신한다.
+
+## 금지사항
+
+- DAG scheduler나 병렬 실행을 구현하지 마라. 이유: Step 9 범위다.
+- 기존 phase 파일을 자동 덮어쓰지 마라. 이유: v1 보존 계약을 위반한다.
+- 새 필드가 없다는 이유로 v1 입력을 실패시키지 마라. 이유: additive schema다.
+- 기존 테스트를 깨뜨리지 마라.

--- a/phases/harness-v2-modernization/step4.md
+++ b/phases/harness-v2-modernization/step4.md
@@ -1,0 +1,41 @@
+# 단계 4: isolated-worktree (#17)
+
+## 읽어야 할 파일
+
+- `/phases/harness-v2-modernization/README.md`
+- `/phases/harness-v2-modernization/COMPATIBILITY.md`
+- `/docs/adr/0001-step-pr-workflow.md`
+- `/scripts/execute.py`
+- `/scripts/autopilot.py`
+- `/scripts/tests/test_execute.py`
+- `/scripts/tests/test_autopilot.py`
+
+## 작업
+
+- task별 branch, worktree, owner와 lifecycle을 별도 모듈로 관리한다.
+- primary checkout의 branch를 전환하지 않고 동시성 1로 구현·검증·리뷰한다.
+- 성공 task만 안전하게 정리하고 실패 또는 blocked task는 재개할 수 있도록
+  보존한다. base sync, PR merge와 state 갱신은 직렬화한다.
+- Windows path와 stale worktree를 포함한 테스트를 추가한다.
+
+## 인수 기준
+
+```powershell
+python -m pytest scripts/tests/test_execute.py scripts/tests/test_autopilot.py
+python scripts/doctor.py --template
+git diff --check
+```
+
+## 검증 절차
+
+1. 생성·소유권·보존·정리·stale fixture test를 먼저 작성한다.
+2. primary checkout branch와 사용자 worktree가 실행 전후 동일한지 확인한다.
+3. 실패 task에서 재개 정보가 남고 성공 task만 정리되는지 자체 리뷰한다.
+4. 성공하면 index의 해당 step을 `completed`와 한 줄 `summary`로 갱신한다.
+
+## 금지사항
+
+- 복수 task를 동시에 실행하지 마라. 이유: bounded concurrency는 Step 9 범위다.
+- 사용자 worktree 또는 branch를 자동 삭제하지 마라. 이유: 소유권이 불명확하다.
+- `git reset --hard`나 force push를 사용하지 마라. 이유: 복구 불가능한 변경을 막는다.
+- 기존 테스트를 깨뜨리지 마라.

--- a/phases/harness-v2-modernization/step5.md
+++ b/phases/harness-v2-modernization/step5.md
@@ -1,0 +1,45 @@
+# 단계 5: sdk-spike (#18)
+
+## 읽어야 할 파일
+
+- `/phases/harness-v2-modernization/README.md`
+- `/phases/harness-v2-modernization/EVALS.md`
+- `/phases/harness-v2-modernization/COMPATIBILITY.md`
+- `/scripts/codex_common.py`
+- `/scripts/execute.py`
+- `/scripts/autopilot.py`
+- `/docs/ADR.md`
+- `/docs/adr/`
+
+## 작업
+
+- 안정 버전 Python Codex SDK의 thread start, run, resume, Windows 인증, sandbox,
+  approval, timeout, interrupt, 오류 복구와 model capability를 재현 가능한 spike로
+  검증한다.
+- 기존 `codex exec`와 설치, runtime, 출력, 테스트 난이도, native review 가능 범위와
+  위험을 비교한다.
+- GO 또는 NO-GO, 전환 전제와 `codex exec` fallback 조건을 새 ADR로 남긴다.
+
+## 인수 기준
+
+```powershell
+python -m pytest scripts
+python scripts/doctor.py --template
+git diff --check
+```
+
+## 검증 절차
+
+1. 고정된 SDK 버전, 환경과 spike 명령을 기록한다.
+2. 성공과 의도된 실패를 모두 재현하고 결과 artifact에서 secret을 검사한다.
+3. ADR과 `COMPATIBILITY.md` fallback 원칙이 일치하는지 자체 리뷰한다.
+4. 성공하면 index의 해당 step을 `completed`와 한 줄 `summary`로 갱신한다.
+
+## 금지사항
+
+- 기존 runner를 제거하거나 production 기본 경로를 전환하지 마라. 이유: spike는
+  의사결정 단계다.
+- 실험적 App Server API를 필수 의존성으로 만들지 마라. 이유: 안정성 검증 범위를
+  벗어난다.
+- credential이나 thread 원문을 커밋하지 마라. 이유: 민감정보 경계를 위반한다.
+- 기존 테스트를 깨뜨리지 마라.

--- a/phases/harness-v2-modernization/step6.md
+++ b/phases/harness-v2-modernization/step6.md
@@ -1,0 +1,44 @@
+# 단계 6: runner-adapter (#19)
+
+## 읽어야 할 파일
+
+- `/phases/harness-v2-modernization/README.md`
+- `/phases/harness-v2-modernization/COMPATIBILITY.md`
+- `/docs/ADR.md`
+- `/scripts/codex_common.py`
+- `/scripts/execute.py`
+- `/scripts/autopilot.py`
+- `/scripts/tests/test_codex_common.py`
+- `/scripts/tests/test_execute.py`
+- `/scripts/tests/test_autopilot.py`
+
+## 작업
+
+- `start`, `run`, `resume`, `review`, `interrupt` 공통 runner contract와 정규화된
+  결과 모델을 정의한다.
+- Step 5 ADR에 따라 SDK 또는 exec adapter를 추가하고 구현·review-fix thread를
+  지속한다.
+- capability 검증 뒤 adapter를 선택하고 실패 시 명시적으로 기존 `codex exec`
+  fallback을 사용한다.
+
+## 인수 기준
+
+```powershell
+python -m pytest scripts/tests/test_codex_common.py scripts/tests/test_execute.py scripts/tests/test_autopilot.py
+python scripts/doctor.py --template
+git diff --check
+```
+
+## 검증 절차
+
+1. 공통 contract와 adapter별 정상·resume·timeout·fallback test를 먼저 작성한다.
+2. executor와 autopilot이 구체 호출 명령을 직접 구성하지 않는지 확인한다.
+3. model/effort capability 오류와 결과 정규화를 자체 리뷰한다.
+4. 성공하면 index의 해당 step을 `completed`와 한 줄 `summary`로 갱신한다.
+
+## 금지사항
+
+- task 병렬 실행을 추가하지 마라. 이유: Step 9 범위다.
+- 모든 오류를 무조건 retry하지 마라. 이유: 비복구 오류와 사람 개입을 구분해야 한다.
+- fallback에서 기존 safety gate를 생략하지 마라. 이유: 호환성보다 안전성이 우선이다.
+- 기존 테스트를 깨뜨리지 마라.

--- a/phases/harness-v2-modernization/step7.md
+++ b/phases/harness-v2-modernization/step7.md
@@ -1,0 +1,43 @@
+# 단계 7: resumable-telemetry (#20)
+
+## 읽어야 할 파일
+
+- `/phases/harness-v2-modernization/README.md`
+- `/phases/harness-v2-modernization/EVALS.md`
+- `/phases/harness-v2-modernization/COMPATIBILITY.md`
+- `/scripts/execute.py`
+- `/scripts/autopilot.py`
+- `/scripts/codex_common.py`
+- `/scripts/tests/`
+
+## 작업
+
+- run, task, issue, thread, worktree, branch, model, effort, attempt, 검증과 review
+  상태 및 상태 전이를 정의한다.
+- state를 원자적으로 기록하고 중단 후 resume 또는 reconcile하며 stale process를
+  식별한다.
+- 완료 action의 idempotency를 보장하고 `EVALS.md` 최소 필드 중 제공 가능한 측정값을
+  생성한다.
+
+## 인수 기준
+
+```powershell
+python -m pytest scripts
+python scripts/doctor.py --template
+git diff --check
+```
+
+## 검증 절차
+
+1. 상태 전이, atomic write 실패, 손상 state, stale process, 중복 완료 action과
+   redaction test를 먼저 작성한다.
+2. EVAL-RESUME을 실행해 task·thread·worktree가 동일하게 재식별되는지 확인한다.
+3. 로그와 state에 credential, 전체 prompt, private thread 원문이 없는지 검사한다.
+4. 성공하면 index의 해당 step을 `completed`와 한 줄 `summary`로 갱신한다.
+
+## 금지사항
+
+- 원격 telemetry 서비스나 dashboard를 추가하지 마라. 이유: 로컬 상태 계약 범위다.
+- 병렬 scheduler를 구현하지 마라. 이유: Step 9 범위다.
+- 미제공 token 값을 0으로 기록하지 마라. 이유: 미측정과 실제 0을 구분해야 한다.
+- 기존 테스트를 깨뜨리지 마라.

--- a/phases/harness-v2-modernization/step8.md
+++ b/phases/harness-v2-modernization/step8.md
@@ -1,0 +1,43 @@
+# 단계 8: risk-based-review (#21)
+
+## 읽어야 할 파일
+
+- `/phases/harness-v2-modernization/README.md`
+- `/phases/harness-v2-modernization/COMPATIBILITY.md`
+- `/.agents/skills/review/SKILL.md`
+- `/docs/adr/0001-step-pr-workflow.md`
+- `/scripts/autopilot.py`
+- `/scripts/codex_common.py`
+- `/scripts/tests/test_autopilot.py`
+- `/scripts/tests/test_codex_common.py`
+
+## 작업
+
+- 기존 read-only review를 공통 adapter로 이동하고 지원되는 경우 native review를
+  사용하되 capability 또는 실행 실패 시 기존 방식으로 fallback한다.
+- 일반 task는 reviewer 1명, 고위험 task만 risk에 맞는 전문 review를 추가한다.
+- review 전후 worktree 불변조건과 기존 local checks, diff, scope, CI gate 의미를
+  유지한다.
+
+## 인수 기준
+
+```powershell
+python -m pytest scripts/tests/test_autopilot.py scripts/tests/test_codex_common.py
+python scripts/doctor.py --template
+git diff --check
+```
+
+## 검증 절차
+
+1. risk 선택, native success/failure fallback, read-only 변경 감지 test를 먼저 쓴다.
+2. review 중 파일 변경 시 PR ready 전 실패하는지 확인한다.
+3. 위험도가 낮은 task에 불필요한 reviewer가 실행되지 않는지 자체 리뷰한다.
+4. 성공하면 index의 해당 step을 `completed`와 한 줄 `summary`로 갱신한다.
+
+## 금지사항
+
+- 모든 task에 여러 reviewer를 강제하지 마라. 이유: 비용과 지연을 위험도에 맞춘다.
+- local checks, diff check, scope scan 또는 CI를 native review로 대체하지 마라.
+  이유: 기존 gate를 보존해야 한다.
+- review가 worktree를 변경한 상태로 통과시키지 마라. 이유: read-only 계약 위반이다.
+- 기존 테스트를 깨뜨리지 마라.

--- a/phases/harness-v2-modernization/step9.md
+++ b/phases/harness-v2-modernization/step9.md
@@ -1,0 +1,41 @@
+# 단계 9: bounded-dag (#22)
+
+## 읽어야 할 파일
+
+- `/phases/harness-v2-modernization/README.md`
+- `/phases/harness-v2-modernization/EVALS.md`
+- `/phases/harness-v2-modernization/COMPATIBILITY.md`
+- `/scripts/execute.py`
+- `/scripts/autopilot.py`
+- `/scripts/tests/`
+
+## 작업
+
+- missing, self dependency와 cycle을 Codex 호출 전에 검증하고 충족된 task의 ready
+  set만 계산한다.
+- task 실행은 기본 동시성 2와 명시적 상한 안에서 병렬화하되 merge와 state 갱신은
+  직렬화한다.
+- 공유 자원별 lock, 실패·중단·재개·reconcile 규칙을 구현한다.
+
+## 인수 기준
+
+```powershell
+python -m pytest scripts
+python scripts/doctor.py --template
+git diff --check
+```
+
+## 검증 절차
+
+1. invalid DAG, ready set, 상한, dependency 순서, 충돌, 중단 후 reconcile test를
+   먼저 작성한다.
+2. EVAL-DEPS를 실행해 task 실행만 병렬이고 PR merge/state 갱신은 직렬인지 확인한다.
+3. 동일 공유 자원을 가진 task가 lock 없이 동시에 실행되지 않는지 자체 리뷰한다.
+4. 성공하면 index의 해당 step을 `completed`와 한 줄 `summary`로 갱신한다.
+
+## 금지사항
+
+- 무제한 concurrency를 허용하지 마라. 이유: 비용과 공유 자원 충돌을 제한해야 한다.
+- 불명확한 dependency를 추측하지 마라. 이유: 잘못된 실행 순서를 만들 수 있다.
+- 여러 PR을 동시에 merge하지 마라. 이유: base와 state 전이를 직렬화해야 한다.
+- 기존 테스트를 깨뜨리지 마라.

--- a/phases/index.json
+++ b/phases/index.json
@@ -1,3 +1,8 @@
 {
-  "phases": []
+  "phases": [
+    {
+      "dir": "harness-v2-modernization",
+      "status": "pending"
+    }
+  ]
 }


### PR DESCRIPTION
## 작업 내용
- phases/harness-v2-modernization에 #13~#23의 순차 실행 계약을 추가했습니다.
- 현재 TEMPLATE_VERSION, execute/autopilot 경로, 세 운영체제 CI, doctor와 175개 unit test 기준선을 기록했습니다.
- 대표 eval 6종과 성공률, first-pass 검증률, 재시도, wall time, 사람 개입, 가능한 token 지표의 계산 및 기록 방법을 정의했습니다.
- v1 phase/index 보존 기준, fallback, rollback trigger와 복구 절차를 문서화했습니다.

## 변경 이유
Harness v2 변경 전 비교 가능한 사실과 품질 gate를 먼저 고정해 후속 Issue가 같은 입력과 기준으로 품질, 안전성, 효율을 평가할 수 있게 합니다.

## 테스트 및 확인
- uv run --with pytest python -m pytest scripts: 175 passed
- Codex 번들 Python scripts/doctor.py --template: PASS
- Codex 번들 Python scripts/checks.py --docs-check-config phases/harness-v2-modernization/docs-checks.json --docs-check: PASS
- git diff --check: PASS
- 자체 리뷰: 범위, ADR, CRITICAL 규칙, step 구조와 Issue #13 완료 조건 통과
- 기준 main CI run 27660324520: Ubuntu, macOS, Windows 모두 success

## 알려진 제한
- 현재 Codex 셸 PATH에 python 실행 파일이 없어 Issue에 적힌 python 명령은 직접 시작되지 않았습니다. 동일 스크립트를 uv 임시 환경과 Codex 번들 Python으로 실행해 결과를 분리 기록했습니다.
- 대표 task의 v1/v2 반복 eval 값은 아직 미측정이며 0으로 간주하지 않습니다. Step 10(#23)에서 고정된 fixture와 조건으로 측정합니다.
- 이 PR은 문서 계약만 추가하며 실행기, worktree, SDK, DAG, 병렬 실행 동작을 변경하지 않습니다.

Closes #13