### PR TITLE
fix: Codex 실행 환경 변수 상속 최소화

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -3,3 +3,15 @@
 # same stable feature as `hooks`.
 codex_hooks = true
 hooks = true
+
+# Codex command shells receive the platform's conservative core environment.
+# The explicit CLI settings in scripts/codex_common.py keep this policy in
+# force for execute.py and autopilot.py even when a project overrides config.
+[shell_environment_policy]
+inherit = "core"
+ignore_default_excludes = false
+
+# Add only non-secret project runtime names when a project truly needs them.
+# An `include` entry becomes an allowlist, so keep the required core names such
+# as PATH in the table when adding any project-specific entry.
+[shell_environment_policy.filters]

--- a/.codex/project-profile.json
+++ b/.codex/project-profile.json
@@ -1,6 +1,6 @@
 {
   "projectName": "<project-name>",
-  "templateVersion": "2026.06.17",
+  "templateVersion": "2026.09.04",
   "profile": "mixed",
   "guardMode": "soft",
   "commands": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 형식, doctor 검사 등)를 먼저 확인합니다. 절차는
 [guides/UPGRADE.md](guides/UPGRADE.md)를 따릅니다.
 
+## 2026.09.04
+
+### Changed
+- Codex 실행 명령의 환경 상속을 `core`로 줄이고, 공식 기본 secret-name 제외
+  정책을 활성화했습니다. 프로젝트별 non-secret runtime 환경 변수는
+  `.codex/config.toml`의 `shell_environment_policy.filters`에서 명시적으로
+  확장합니다.
+
 ## 2026.06.17
 
 ### Added

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -7,3 +7,4 @@
 
 ## ADR 목록
 - [ADR-0001: Harness Step PR Workflow](adr/0001-step-pr-workflow.md)
+- [ADR-0002: Codex subprocess 환경 상속 최소화](adr/0002-minimize-codex-environment.md)

--- a/docs/adr/0002-minimize-codex-environment.md
+++ b/docs/adr/0002-minimize-codex-environment.md
@@ -1,0 +1,50 @@
+# ADR-0002: Codex subprocess 환경 상속 최소화
+
+- 상태: Accepted
+- 날짜: 2026-09-04
+- 관련 이슈: #14
+
+## 문맥
+
+Harness의 Codex 실행 명령은 이전에 `shell_environment_policy.inherit=all`을
+명시해 부모 환경 전체를 Codex subprocess에 노출했다. 실행 파일 탐색은 현재
+프로세스의 `PATH`와 플랫폼별 `codex` 후보를 사용해야 하지만, 인증·토큰 이름의
+환경 변수까지 명령 환경에 넓게 전달할 필요는 없다.
+
+## 결정
+
+1. `scripts/codex_common.py`의 공통 명령 생성기는
+   `shell_environment_policy.inherit="core"`를 사용한다. `execute.py`의 구현
+   호출과 `autopilot.py`의 review/fix 호출이 같은 생성기를 공유한다.
+2. `shell_environment_policy.ignore_default_excludes=false`를 명시한다. 이 값은
+   Codex의 공식 기본 secret-name 제외 규칙을 켜며, credential 값을 Harness가
+   직접 다루거나 재구성하지 않는다.
+3. 프로젝트별 non-secret runtime 확장은 프로젝트 루트
+   `.codex/config.toml`의 `[shell_environment_policy.filters]`에서 변수 이름으로
+   선언한다. `include`가 allowlist를 만들 수 있으므로 `PATH`와 필요한 core
+   변수도 함께 명시해야 한다.
+4. 기존 legacy `include_only`/`exclude` 배열이나 사용자 전역 Codex 설정은
+   사용하지 않는다. 플랫폼별 `shutil.which` 후보 탐색은 변경하지 않는다.
+
+공식 설정 의미는 [Codex Configuration Reference](https://developers.openai.com/codex/config-reference/)
+및 [Config basics](https://developers.openai.com/codex/config-basic/)를 따른다.
+
+## 결과와 한계
+
+- 기본 실행은 core 환경과 `PATH`를 유지하면서 부모 환경 전체 상속을 피한다.
+- 공식 기본 제외 규칙에 따라 secret-name 변수는 Codex shell 환경에 전달되지
+  않는다. 프로젝트가 allowlist를 추가할 때에는 이름만 검토해야 한다.
+- `.codex/config.toml`은 템플릿의 설정 확장 지점이므로 업그레이드 시
+  `guides/UPGRADE.md`의 소유 구분과 프로젝트별 설정을 함께 검토한다.
+- 이 결정은 Codex CLI 자체의 인증 저장 방식이나 부모 Python 프로세스의 인증
+  환경을 변경하지 않는다. 즉, Codex를 시작하는 데 필요한 인증 경계는 기존
+  동작으로 남긴다.
+
+## 검증
+
+- 공통 명령에 `core`와 기본 secret-name 제외 설정이 포함되고 `inherit=all` 및
+  legacy 키가 사라졌는지 단위 테스트로 확인한다.
+- Windows, macOS, Linux 후보에 대해 `PATH` 기반 `codex` runtime 탐색 계약을
+  parameterized test로 확인한다.
+- 프로젝트 config의 filters 확장 테이블과 secret-name fixture가 credential
+  값을 포함하지 않는지 확인한다.

--- a/guides/CONFIGURATION.md
+++ b/guides/CONFIGURATION.md
@@ -54,6 +54,28 @@ profile override가 없으면 `docs/COMMANDS.md`, 그 다음 프로젝트 manife
 - Python: `pyproject.toml`, `uv.lock`, `pytest`, `ruff`
 - Node: `package.json`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`
 
+## Codex subprocess 환경
+
+Harness가 `execute.py`와 `autopilot.py`에서 실행하는 Codex 명령은
+`shell_environment_policy.inherit="core"`를 사용합니다. 플랫폼별 핵심 환경과
+`PATH`는 유지하면서 전체 부모 환경을 그대로 넘기지 않습니다. 또한
+`shell_environment_policy.ignore_default_excludes=false`를 함께 지정해 Codex의
+공식 기본 제외 규칙(이름에 `KEY`, `SECRET`, `TOKEN`이 포함된 변수)을 적용합니다.
+
+프로젝트에 꼭 필요한 non-secret runtime 변수만 다음 공식 확장 지점에 이름으로
+추가합니다.
+
+```toml
+[shell_environment_policy.filters]
+"PATH" = "include"
+"PROJECT_RUNTIME_HOME" = "include"
+```
+
+`include`를 하나라도 추가하면 필터가 allowlist가 되므로, 필요한 경우 `PATH`와
+프로젝트가 요구하는 core 변수를 함께 적습니다. credential 값이나 secret-name
+변수는 이 파일과 fixture에 넣지 않습니다. `execute.py`와 autopilot의 Codex
+호출은 공통 명령 생성기를 사용하므로 두 실행 경로의 정책이 달라지지 않습니다.
+
 ## Scope Rules
 
 scope rule은 MVP 범위 밖 기능이 step PR에 끼어드는 것을 막기 위한 데이터 기반

--- a/phases/harness-v2-modernization/index.json
+++ b/phases/harness-v2-modernization/index.json
@@ -9,7 +9,13 @@
       "completed_at": "2026-09-03T15:40:23Z",
       "summary": "Harness v1 기준선, 대표 eval 지표, #14~#23 실행 순서와 호환·rollback 계약을 고정했다."
     },
-    { "step": 1, "name": "minimize-environment-inheritance", "status": "pending" },
+    {
+      "step": 1,
+      "name": "minimize-environment-inheritance",
+      "status": "completed",
+      "completed_at": "2026-09-04T08:57:34Z",
+      "summary": "Codex 실행을 core 환경과 공식 secret-name 제외 정책으로 제한하고 프로젝트별 filters 확장 지점을 고정했다."
+    },
     { "step": 2, "name": "progressive-guardrails", "status": "pending" },
     { "step": 3, "name": "task-schema-v2", "status": "pending" },
     { "step": 4, "name": "isolated-worktree", "status": "pending" },

--- a/scripts/autopilot.py
+++ b/scripts/autopilot.py
@@ -19,9 +19,9 @@ import guard
 from codex_common import (
     ALLOWED_CODEX_EFFORTS,
     CODEX_ENV_CONFIG,
+    CODEX_ENV_SECRET_FILTER_CONFIG,
     CODEX_EXEC_TIMEOUT,
     codex_base_cmd,
-    codex_effort_config,
     configure_utf8_stdio,
     read_acceptance_commands,
     resolve_codex_bin,
@@ -867,16 +867,11 @@ class AutopilotRunner:
         last_message_path = self._temporary_path(".txt")
         try:
             cmd = [
-                resolve_codex_bin(),
-                "exec",
-                *codex_effort_config(self.review_effort),
-                "-c",
-                CODEX_ENV_CONFIG,
+                *codex_base_cmd(self.review_effort),
                 "--output-schema",
                 str(schema_path),
                 "--output-last-message",
                 str(last_message_path),
-                "--json",
                 "-",
             ]
             result = self._run(cmd, check=False, timeout=CODEX_EXEC_TIMEOUT, input_text=prompt)
@@ -905,10 +900,7 @@ class AutopilotRunner:
                 [
                     self._command_failure(
                         [
-                            "codex",
-                            "exec",
-                            *codex_effort_config(self.review_effort),
-                            "--json",
+                            *codex_base_cmd(self.review_effort),
                             "<review-prompt>",
                         ],
                         result,

--- a/scripts/codex_common.py
+++ b/scripts/codex_common.py
@@ -14,11 +14,12 @@ from pathlib import Path
 # .codex/project-profile.json `templateVersion`에 기록하고, doctor가 둘을
 # 비교해 "harness 파일과 동기화 기록이 어긋난 상태"를 잡는다.
 # 업그레이드 절차는 템플릿 guides/UPGRADE.md를 따른다.
-TEMPLATE_VERSION = "2026.06.17"
+TEMPLATE_VERSION = "2026.09.04"
 
 ALLOWED_CODEX_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
 CODEX_EXEC_TIMEOUT = 1800
-CODEX_ENV_CONFIG = "shell_environment_policy.inherit=all"
+CODEX_ENV_CONFIG = 'shell_environment_policy.inherit="core"'
+CODEX_ENV_SECRET_FILTER_CONFIG = "shell_environment_policy.ignore_default_excludes=false"
 ACCEPTANCE_SECTION_HEADER = "## 인수 기준"
 
 
@@ -56,14 +57,23 @@ def codex_effort_config(effort: str) -> list[str]:
     return ["-c", f'model_reasoning_effort="{effort}"']
 
 
+def codex_environment_config() -> list[str]:
+    """Return the conservative environment policy for every Codex invocation."""
+    return [
+        "-c",
+        CODEX_ENV_CONFIG,
+        "-c",
+        CODEX_ENV_SECRET_FILTER_CONFIG,
+    ]
+
+
 def codex_base_cmd(effort: str) -> list[str]:
     return [
         resolve_codex_bin(),
         "exec",
         "--json",
         *codex_effort_config(effort),
-        "-c",
-        CODEX_ENV_CONFIG,
+        *codex_environment_config(),
     ]
 
 

--- a/scripts/execute.py
+++ b/scripts/execute.py
@@ -27,6 +27,7 @@ from codex_common import (
     ALLOWED_CODEX_EFFORTS,
     CODEX_EXEC_TIMEOUT,
     CODEX_ENV_CONFIG,
+    CODEX_ENV_SECRET_FILTER_CONFIG,
     codex_base_cmd,
     configure_utf8_stdio,
     read_acceptance_commands,

--- a/scripts/tests/test_autopilot.py
+++ b/scripts/tests/test_autopilot.py
@@ -340,6 +340,7 @@ def test_codex_review_uses_step_scoped_exec_prompt(runner):
     assert "review" not in seen["cmd"][2:]
     assert "--base" not in seen["cmd"]
     assert ap.CODEX_ENV_CONFIG in seen["cmd"]
+    assert ap.CODEX_ENV_SECRET_FILTER_CONFIG in seen["cmd"]
     assert "--output-schema" in seen["cmd"]
     assert seen["schema"]["required"] == ["pass", "summary", "findings"]
     assert "--output-last-message" in seen["cmd"]
@@ -423,6 +424,7 @@ def test_codex_review_uses_high_reasoning_effort_by_default(runner):
     assert "-c" in seen["cmd"]
     assert 'model_reasoning_effort="high"' in seen["cmd"]
     assert ap.CODEX_ENV_CONFIG in seen["cmd"]
+    assert ap.CODEX_ENV_SECRET_FILTER_CONFIG in seen["cmd"]
 
 
 def test_codex_fix_uses_medium_reasoning_effort(runner, tmp_repo):
@@ -447,6 +449,7 @@ def test_codex_fix_uses_medium_reasoning_effort(runner, tmp_repo):
     assert seen["cmd"][:2] == [ap.CODEX_BIN, "exec"]
     assert 'model_reasoning_effort="medium"' in seen["cmd"]
     assert ap.CODEX_ENV_CONFIG in seen["cmd"]
+    assert ap.CODEX_ENV_SECRET_FILTER_CONFIG in seen["cmd"]
     assert seen["input_text"].startswith("당신은 Harness step PR 자동 리뷰 수정 담당자입니다.")
     assert seen["timeout"] == 1800
 

--- a/scripts/tests/test_codex_common.py
+++ b/scripts/tests/test_codex_common.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+import tomllib
+
 import pytest
 
 import codex_common
@@ -22,6 +25,54 @@ def test_codex_base_cmd_uses_stdin_compatible_exec_shape():
     assert "--json" in cmd
     assert 'model_reasoning_effort="medium"' in cmd
     assert codex_common.CODEX_ENV_CONFIG in cmd
+    assert codex_common.CODEX_ENV_SECRET_FILTER_CONFIG in cmd
+    assert "shell_environment_policy.inherit=all" not in cmd
+    assert "shell_environment_policy.include_only" not in cmd
+    assert "shell_environment_policy.exclude" not in cmd
+
+
+def test_codex_project_config_declares_minimal_policy_and_extension_point():
+    config_path = Path(__file__).resolve().parents[2] / ".codex" / "config.toml"
+    config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+
+    policy = config["shell_environment_policy"]
+    assert policy["inherit"] == "core"
+    assert policy["ignore_default_excludes"] is False
+    assert isinstance(policy["filters"], dict)
+
+
+def test_codex_command_enables_default_secret_name_exclusion_without_values():
+    secret_name_fixture = {
+        "PROJECT_RUNTIME_HOME": "runtime-sentinel",
+        "PAYMENT_API_TOKEN": "secret-name-only",
+        "AWS_SECRET_ACCESS_KEY": "secret-name-only",
+    }
+    cmd = codex_common.codex_base_cmd("medium")
+
+    assert codex_common.CODEX_ENV_SECRET_FILTER_CONFIG in cmd
+    assert all(name not in cmd and value not in cmd for name, value in secret_name_fixture.items())
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected_candidates"),
+    [
+        ("win32", ("codex.cmd", "codex.exe", "codex")),
+        ("darwin", ("codex",)),
+        ("linux", ("codex",)),
+    ],
+)
+def test_resolve_codex_bin_preserves_platform_runtime_lookup(monkeypatch, platform, expected_candidates):
+    calls = []
+
+    def fake_which(candidate):
+        calls.append(candidate)
+        return f"/runtime/{candidate}" if candidate == expected_candidates[-1] else None
+
+    monkeypatch.setattr(codex_common.sys, "platform", platform)
+    monkeypatch.setattr(codex_common.shutil, "which", fake_which)
+
+    assert codex_common.resolve_codex_bin() == f"/runtime/{expected_candidates[-1]}"
+    assert calls == list(expected_candidates)
 
 
 def test_read_acceptance_commands_extracts_fenced_commands(tmp_path):

--- a/scripts/tests/test_execute.py
+++ b/scripts/tests/test_execute.py
@@ -588,6 +588,7 @@ class TestInvokeCodex:
         assert cmd[1] == "exec"
         assert "--json" in cmd
         assert ex.CODEX_ENV_CONFIG in cmd
+        assert ex.CODEX_ENV_SECRET_FILTER_CONFIG in cmd
         assert 'model_reasoning_effort="medium"' in cmd
         assert "--dangerously-bypass-approvals-and-sandbox" not in cmd
         assert cmd[-1] == "-"
@@ -606,6 +607,7 @@ class TestInvokeCodex:
         assert cmd[:2] == [ex.CODEX_BIN, "exec"]
         assert 'model_reasoning_effort="high"' in cmd
         assert ex.CODEX_ENV_CONFIG in cmd
+        assert ex.CODEX_ENV_SECRET_FILTER_CONFIG in cmd
         assert "--json" in cmd
 
     def test_unsafe_adds_bypass_flag(self, executor):


### PR DESCRIPTION
Closes #14

## 작업 내용

- Codex 명령의 `shell_environment_policy.inherit=all`을 제거하고 `core` 상속으로 변경했습니다.
- 공식 `ignore_default_excludes=false`를 공통 명령 생성기에 적용해 secret-name 기본 제외 정책을 사용합니다.
- `execute.py`와 `autopilot.py`의 구현·review·fix 호출이 같은 환경 정책을 공유합니다.
- `.codex/config.toml`에 프로젝트별 non-secret runtime 변수의 명시적 `[shell_environment_policy.filters]` 확장 지점을 추가했습니다.
- ADR, 설정 가이드, CHANGELOG, phase step 완료 메타데이터를 갱신했습니다.

공식 근거: [Codex Configuration Reference](https://developers.openai.com/codex/config-reference/), [Config basics](https://developers.openai.com/codex/config-basic/)

## 변경 이유

부모 환경 전체를 Codex shell subprocess에 전달하지 않고, `PATH`를 포함한 core 환경과 필요한 프로젝트 변수만 명시적으로 허용하기 위함입니다. credential 값은 코드와 fixture에 넣지 않았습니다.

## 검증

- `uv run --with pytest python -m pytest scripts/tests/test_codex_common.py scripts/tests/test_execute.py scripts/tests/test_autopilot.py` — 121 passed
- `uv run --with pytest python -m pytest scripts` — 180 passed
- `uv run --with pytest python -m compileall -q scripts` — passed
- `uv run --with pytest python scripts/doctor.py --template` — passed
- `uv run --with pytest python scripts/checks.py --docs-check-config phases/harness-v2-modernization/docs-checks.json --docs-check` — passed
- `codex exec --help --strict-config` 및 CLI `-c` 환경 정책 파싱 — passed
- `git diff --check` — passed
- Windows/macOS/Linux 후보의 `PATH` 기반 runtime lookup parameterized test — passed locally and in remote Template CI (Ubuntu/macOS/Windows)

현재 셸에는 `python` 실행 파일이 없어 Issue #14에 적힌 직접 명령은 `python: The term 'python' is not recognized`로 실행되지 않았고, 동일 검증을 `uv run --with pytest python ...`으로 대체했습니다. 템플릿의 `docs/COMMANDS.md`가 `test`/`build` placeholder라 `checks.py --stage manual/final`은 해당 명령 미설정으로 실패하며, 이번 변경과 무관한 기존 템플릿 상태입니다.

## 위험 및 완화

- `filters`에 `include`를 추가하면 allowlist가 되므로 가이드에 `PATH`와 필요한 core 변수도 함께 선언하도록 적었습니다.
- Codex CLI를 시작하는 부모 Python 프로세스의 기존 인증 경계는 변경하지 않았습니다.
- 사용자 전역 Codex 설정과 후속 #15 이후 기능은 변경하지 않았습니다.