### PR TITLE
refactor: guardrail prompt를 progressive disclosure로 전환

### DIFF
--- a/.agents/skills/harness/SKILL.md
+++ b/.agents/skills/harness/SKILL.md
@@ -257,7 +257,14 @@ python scripts/autopilot.py {작업명} --max-review-fixes 2  # phase 전체 구
 python scripts/autopilot.py {작업명} --dry-run --max-steps 1
 ```
 
-`scripts/execute.py`는 브랜치 생성, `AGENTS.md`, phase `README.md`, 참조된 `docs/*.md`, `docs/COMMANDS.md`의 가드레일 주입, 완료된 단계의 `summary` 컨텍스트 전달, 재시도 피드백, 코드 변경과 메타데이터의 2단계 커밋, completed 보고 후 인수 기준 재검증, 타임스탬프 기록, 선택적 push를 처리한다. 기본 실행은 Codex 승인과 sandbox를 유지하며, 필요한 경우에만 `--unsafe`를 명시한다. `.codex/project-profile.json`의 `guardrailDocs`가 있으면 그 문서 목록이 우선 첨부된다.
+`scripts/execute.py`는 브랜치 생성, `AGENTS.md`·phase·관련 문서의 직접 읽기 경로
+검증, 현재 step의 objective/acceptance criteria/hard constraints와 완료된 단계의
+`summary` context 전달, 재시도 피드백, 코드 변경과 메타데이터의 2단계 커밋,
+completed 보고 후 인수 기준 재검증, 타임스탬프 기록, 선택적 push를 처리한다.
+문서 본문은 prompt에 첨부하지 않고 Codex가 저장소에서 직접 읽는다.
+`.codex/project-profile.json`의 비어 있지 않은 `guardrailDocs`는 문서 본문이
+아닌 경로 선택 목록이며, 누락·판독 불가 경로는 Codex 호출 전에 진단한다. 기본
+실행은 Codex 승인과 sandbox를 유지하며, 필요한 경우에만 `--unsafe`를 명시한다.
 `scripts/execute.py`는 `--step` 또는 `--next-step-only`가 아닌 전체 phase 실행에서 모든 pending step이 완료되면 `python scripts/checks.py --stage final`을 실행한다.
 
 `scripts/autopilot.py`는 clean worktree에서 다음 pending step을 `codex/{phase}-step{N}-{name}` 브랜치로 실행하고 Draft PR을 만든다. `--base`를 생략하면 origin HEAD를 사용하고 실패 시 `main`으로 fallback한다. step 인수 기준, diff check, scope rule scan, Codex read-only review, 원격 PR checks가 통과하면 ready 전환 후 squash merge한다. 실패하면 PR 코멘트, GitHub Issue, `issues/{phase}/issue-N.md`를 남기고 같은 PR 브랜치에서 제한 횟수만큼 자동 수정과 재리뷰를 수행한다. 재시도 후에도 실패하면 PR과 Issue를 열어둔 채 중단한다.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   정책을 활성화했습니다. 프로젝트별 non-secret runtime 환경 변수는
   `.codex/config.toml`의 `shell_environment_policy.filters`에서 명시적으로
   확장합니다.
+- guardrail prompt를 progressive disclosure 방식으로 전환했습니다. prompt에는
+  작업 계약과 직접 읽을 경로만 전달하고, 선택 경로의 누락·판독 불가 상태는
+  Codex 호출 전에 진단합니다.
 
 ## 2026.06.17
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ MVP 범위, 기술 스택, 검증 명령, phase 경계를 먼저 문서로 확�
 | 3 | `docs/PRD.md` | 목표, 사용자, MVP 범위, 완료 기준, 제외 범위 | MVP 안팎을 Codex가 구분할 수 있음 |
 | 4 | `docs/ARCHITECTURE.md` | 기술 스택, 디렉터리 구조, 모듈 경계, 데이터 흐름, 테스트 전략 | 구현 경계와 검증 방식이 한 문서에 정리됨 |
 | 5 | `docs/ADR.md`, `docs/adr/*` | 되돌리면 안 되는 기술 결정과 변경 규칙 | 주요 선택의 이유와 상태가 기록됨 |
-| 6 | `docs/COMMANDS.md`, `.codex/project-profile.json` | 확정된 기술 스택 기준의 `dev`, `lint`, `test`, `build`, `profile`, `sourceRoots`, `testRoots`, 필요 시 `stageChecks`, `guardrailDocs` | 최소 `test`와 `build`가 비어 있지 않거나 manifest로 감지 가능 |
+| 6 | `docs/COMMANDS.md`, `.codex/project-profile.json` | 확정된 기술 스택 기준의 `dev`, `lint`, `test`, `build`, `profile`, `sourceRoots`, `testRoots`, 필요 시 `stageChecks`, `guardrailDocs` 경로 선택 | 최소 `test`와 `build`가 비어 있지 않거나 manifest로 감지 가능 |
 | 7 | `AGENTS.md` | 프로젝트명, 목표, 스택, 명령어, CRITICAL 규칙 | 템플릿 placeholder가 남아 있지 않음 |
 | 8 | `scripts/doctor.py --instance` | 복사한 프로젝트의 적용 상태 점검 | doctor가 exit code 0으로 종료 |
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -52,7 +52,8 @@ autopilot 운영 안전장치:
 - PR은 `gh pr checks --watch`로 원격 체크 통과를 확인한 뒤에만 squash merge한다.
 - `no checks reported`는 ready 직후 체크 생성 전 레이스일 수 있어 grace 동안 재확인한다. CI가 없는 저장소는 `--allow-no-checks`로 대기를 생략할 수 있다.
 - 금지 범위 규칙은 `.codex/scope-rules.json`의 `forbidden`, phase별 확장/허용은 `phases/<phase>/scope-rules.json`의 `extraForbidden`, `allowedScopeMessages`로 관리한다.
-- `execute.py`는 phase README/step 문서가 참조하는 `docs/*.md`만 기본 첨부한다. `.codex/project-profile.json`의 `guardrailDocs`가 있으면 그 목록이 우선한다.
+- `execute.py`의 guardrail prompt에는 문서 본문을 첨부하지 않고, Codex가 직접 읽어야 할 저장소 상대 경로만 기록한다. `guardrailDocs`가 비어 있지 않으면 그 목록을 우선하고, 비어 있거나 없으면 phase 문서 참조와 canonical 문서 fallback을 사용한다. 현재 step의 `읽어야 할 파일`도 경로 목록에 포함한다.
+- AGENTS, phase 문서, profile 또는 step이 지정한 경로가 누락되거나 읽을 수 없으면 Codex를 호출하기 전에 명확한 오류로 중단한다. `guardrailDocs`는 문서 내용이 아니라 경로 선택 입력이다.
 
 `scope-rules.json` rule schema:
 

--- a/guides/CONFIGURATION.md
+++ b/guides/CONFIGURATION.md
@@ -54,6 +54,27 @@ profile override가 없으면 `docs/COMMANDS.md`, 그 다음 프로젝트 manife
 - Python: `pyproject.toml`, `uv.lock`, `pytest`, `ruff`
 - Node: `package.json`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`
 
+## Progressive guardrails
+
+`scripts/execute.py`는 Codex prompt에 AGENTS, phase 문서, 관련 문서의 본문을
+복사하지 않습니다. 대신 작업 목표, acceptance criteria, hard constraints, 이전
+step summary와 Codex가 저장소에서 직접 읽어야 할 경로를 전달합니다. 문서 본문은
+Codex가 해당 경로를 읽을 때만 context에 들어옵니다.
+
+`guardrailDocs`는 기존과 같이 경로 선택 입력입니다.
+
+1. 비어 있지 않은 `guardrailDocs` 목록을 명시하면 그 목록을 사용합니다.
+2. 목록이 비어 있거나 키가 없으면 phase README/step 문서가 참조한 경로를
+   사용합니다.
+3. 참조 경로가 없으면 `docs/PRD.md`, `docs/ARCHITECTURE.md`, `docs/ADR.md`,
+   `docs/COMMANDS.md`, `docs/SCOPE_CHANGE_CHECKLIST.md` 중 존재하는 경로를
+   fallback으로 사용합니다.
+
+모든 경로는 저장소 상대 경로여야 합니다. 선택된 경로와 현재 step의 `읽어야 할
+파일`이 누락되거나 읽을 수 없으면 Codex 실행 전에 실패하므로, 잘못된 문서 참조를
+조용히 건너뛰지 않습니다. `guardrailDocs: []`는 자동 선택을 의미하며 문서 본문을
+prompt에 포함하라는 뜻이 아닙니다.
+
 ## Codex subprocess 환경
 
 Harness가 `execute.py`와 `autopilot.py`에서 실행하는 Codex 명령은

--- a/phases/harness-v2-modernization/EVALS.md
+++ b/phases/harness-v2-modernization/EVALS.md
@@ -84,6 +84,37 @@ wall time, 사람 개입, token은 성공 실행만 따로 요약하되 실패 �
 민감정보, credential, 전체 prompt, private thread 원문은 결과 레코드에 저장하지
 않는다.
 
+## Issue #15 측정 결과
+
+아래 결과는 EVAL-DOCS와 EVAL-CODE의 대표 fixture를 사용한 **prompt 구성 계약
+proxy**다. v1은 Issue #15 부모 branch의 기존 전체 문서 첨부 방식이며, v2는
+`9904ec7652f2d28bf5dc938274c124e99a4b6bd7`의 경로 중심 방식이다. Codex가 실제
+작업을 수행하거나 CI/PR gate를 통과한 결과가 아니므로 task 성공률 개선으로
+해석하지 않는다. PR #25에서 고정한 동일 variant/scenario/repetition, 3회 반복,
+동일 fixture·gate, token 미제공 시 `null` 기록 규칙을 적용했다.
+
+- fixture: `harness-v2-modernization` Step 2 `progressive-guardrails`
+- v1 기준 commit: `eb7192d`
+- v2 구현 commit: `9904ec7652f2d28bf5dc938274c124e99a4b6bd7`
+- fixture SHA-256: `9a6a50f1e7ee67595859c166a10c460012b224f34e5c543ce34fb3ae804c1644`
+- 재현 명령: `uv run --with pytest python -X utf8 scripts/eval_progressive_guardrails.py --phase harness-v2-modernization --step 2 --v1-commit eb7192d`
+- 조건: Windows 11 `10.0.26200`, Python `3.12.13`, Codex CLI `0.146.0`, effort
+  `medium`, 동일 fixture, variant별 3회, retry 상한 `3`, `setupIncluded=false`,
+  sandbox/approval/model 미호출, cache 상태 `not applicable`
+
+| variant | prompt 문자 수 | UTF-8 byte 수 | 계약 품질 통과 | 문서 본문 부재 |
+| --- | ---: | ---: | --- | --- |
+| v1 | 17,233 | 26,066 | 3/3 | 0/3 |
+| v2 | 2,565 | 3,814 | 3/3 | 3/3 |
+
+v2는 v1보다 prompt가 14,668자, 22,252 byte 줄어 UTF-8 기준 86.03% 감소했다.
+양쪽 모두 acceptance command, hard constraint, 직접 읽기 경로, step 작업 정의를
+3/3 보존했고, v2는 문서 본문을 3/3회 prompt에 포함하지 않았다. Codex 호출을
+수행하지 않은 proxy이므로 token 지표는 `null`이며 사유는
+`prompt proxy does not invoke codex exec and stores no prompt text`이다. 실제
+EVAL-DOCS/EVAL-CODE 성공률, first-pass, wall time, CI 및 hard gate는 Step 10
+release eval에서 같은 조건으로 별도 측정해야 한다.
+
 ## 릴리스 판정
 
 - hard gate: EVAL-V1과 EVAL-SAFETY 100% 성공, unit test·doctor·upgrade 검증 통과,

--- a/phases/harness-v2-modernization/EVALS.md
+++ b/phases/harness-v2-modernization/EVALS.md
@@ -88,14 +88,15 @@ wall time, 사람 개입, token은 성공 실행만 따로 요약하되 실패 �
 
 아래 결과는 EVAL-DOCS와 EVAL-CODE의 대표 fixture를 사용한 **prompt 구성 계약
 proxy**다. v1은 Issue #15 부모 branch의 기존 전체 문서 첨부 방식이며, v2는
-`9904ec7652f2d28bf5dc938274c124e99a4b6bd7`의 경로 중심 방식이다. Codex가 실제
+`25787d2580c86830ebd4d6f5799a032d406a591c`의 경로 중심 방식이다. Codex가 실제
 작업을 수행하거나 CI/PR gate를 통과한 결과가 아니므로 task 성공률 개선으로
 해석하지 않는다. PR #25에서 고정한 동일 variant/scenario/repetition, 3회 반복,
 동일 fixture·gate, token 미제공 시 `null` 기록 규칙을 적용했다.
 
 - fixture: `harness-v2-modernization` Step 2 `progressive-guardrails`
 - v1 기준 commit: `eb7192d`
-- v2 구현 commit: `9904ec7652f2d28bf5dc938274c124e99a4b6bd7`
+- v2 구현 commit: `25787d2580c86830ebd4d6f5799a032d406a591c`
+- 평가 도구 최종 commit: `9904ec7652f2d28bf5dc938274c124e99a4b6bd7`
 - fixture SHA-256: `9a6a50f1e7ee67595859c166a10c460012b224f34e5c543ce34fb3ae804c1644`
 - 재현 명령: `uv run --with pytest python -X utf8 scripts/eval_progressive_guardrails.py --phase harness-v2-modernization --step 2 --v1-commit eb7192d`
 - 조건: Windows 11 `10.0.26200`, Python `3.12.13`, Codex CLI `0.146.0`, effort

--- a/phases/harness-v2-modernization/index.json
+++ b/phases/harness-v2-modernization/index.json
@@ -16,7 +16,13 @@
       "completed_at": "2026-09-04T08:57:34Z",
       "summary": "Codex 실행을 core 환경과 공식 secret-name 제외 정책으로 제한하고 프로젝트별 filters 확장 지점을 고정했다."
     },
-    { "step": 2, "name": "progressive-guardrails", "status": "pending" },
+    {
+      "step": 2,
+      "name": "progressive-guardrails",
+      "status": "completed",
+      "completed_at": "2026-09-04T09:42:36Z",
+      "summary": "guardrail prompt를 경로·step 계약 중심으로 축소하고 참조 누락을 Codex 호출 전에 진단했으며 v1 대비 prompt 계약 proxy를 기록했다."
+    },
     { "step": 3, "name": "task-schema-v2", "status": "pending" },
     { "step": 4, "name": "isolated-worktree", "status": "pending" },
     { "step": 5, "name": "sdk-spike", "status": "pending" },

--- a/scripts/eval_progressive_guardrails.py
+++ b/scripts/eval_progressive_guardrails.py
@@ -19,6 +19,7 @@ from execute import ROOT, StepExecutor
 
 DEFAULT_PHASE = "harness-v2-modernization"
 DEFAULT_V1_COMMIT = "eb7192d"
+DEFAULT_STEP = 2
 REPETITIONS = 3
 
 
@@ -34,12 +35,15 @@ def _git_output(*args: str) -> str:
     return result.stdout.strip()
 
 
-def _load_phase_step(phase: str) -> tuple[dict, Path]:
+def _load_phase_step(phase: str, step_number: int | None) -> tuple[dict, Path]:
     phase_dir = ROOT / "phases" / phase
     index = json.loads((phase_dir / "index.json").read_text(encoding="utf-8"))
-    step = next((item for item in index["steps"] if item.get("status") == "pending"), None)
+    if step_number is None:
+        step = next((item for item in index["steps"] if item.get("status") == "pending"), None)
+    else:
+        step = next((item for item in index["steps"] if item.get("step") == step_number), None)
     if step is None:
-        raise RuntimeError(f"phase {phase} has no pending step")
+        raise RuntimeError(f"phase {phase} has no step {step_number}")
     return step, phase_dir / f"step{step['step']}.md"
 
 
@@ -174,8 +178,8 @@ def _codex_version() -> str | None:
     return (result.stdout or result.stderr).strip().splitlines()[0] or None
 
 
-def evaluate(phase: str, v1_commit: str) -> dict:
-    step, step_path = _load_phase_step(phase)
+def evaluate(phase: str, v1_commit: str, step_number: int | None) -> dict:
+    step, step_path = _load_phase_step(phase, step_number)
     v1_prompt = _build_v1_prompt(phase, step, step_path, v1_commit)
     v2_prompt = _build_v2_prompt(phase, step)
     fixture_sha = _fixture_sha256(phase, step_path)
@@ -255,8 +259,9 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--phase", default=DEFAULT_PHASE)
     parser.add_argument("--v1-commit", default=DEFAULT_V1_COMMIT)
+    parser.add_argument("--step", type=int, default=DEFAULT_STEP)
     args = parser.parse_args(argv)
-    print(json.dumps(evaluate(args.phase, args.v1_commit), ensure_ascii=False, indent=2))
+    print(json.dumps(evaluate(args.phase, args.v1_commit, args.step), ensure_ascii=False, indent=2))
     return 0
 
 

--- a/scripts/eval_progressive_guardrails.py
+++ b/scripts/eval_progressive_guardrails.py
@@ -47,17 +47,24 @@ def _load_phase_step(phase: str, step_number: int | None) -> tuple[dict, Path]:
     return step, phase_dir / f"step{step['step']}.md"
 
 
-def _fixture_sha256(phase: str, step_path: Path) -> str:
+def _fixture_sha256(phase: str) -> str:
     phase_dir = ROOT / "phases" / phase
     paths = [
         ROOT / "AGENTS.md",
         phase_dir / "README.md",
-        step_path,
+        phase_dir / "index.json",
+        *sorted(phase_dir.glob("step*.md")),
         ROOT / ".codex" / "project-profile.json",
         ROOT / "docs" / "COMMANDS.md",
+        *sorted((ROOT / "docs").glob("*.md")),
+        *sorted((ROOT / "docs" / "adr").glob("*.md")),
     ]
     digest = hashlib.sha256()
+    seen: set[Path] = set()
     for path in paths:
+        if path in seen or not path.is_file():
+            continue
+        seen.add(path)
         relative = path.relative_to(ROOT).as_posix()
         digest.update(relative.encode("utf-8"))
         digest.update(b"\0")
@@ -182,7 +189,7 @@ def evaluate(phase: str, v1_commit: str, step_number: int | None) -> dict:
     step, step_path = _load_phase_step(phase, step_number)
     v1_prompt = _build_v1_prompt(phase, step, step_path, v1_commit)
     v2_prompt = _build_v2_prompt(phase, step)
-    fixture_sha = _fixture_sha256(phase, step_path)
+    fixture_sha = _fixture_sha256(phase)
     v1_quality = _contract_quality(v1_prompt, phase, step, step_path)
     v2_quality = _contract_quality(v2_prompt, phase, step, step_path)
     repetitions = []

--- a/scripts/eval_progressive_guardrails.py
+++ b/scripts/eval_progressive_guardrails.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Compare the legacy and progressive guardrail prompts without storing prompt text."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import platform
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from codex_common import read_acceptance_commands, resolve_codex_bin
+from execute import ROOT, StepExecutor
+
+
+DEFAULT_PHASE = "harness-v2-modernization"
+DEFAULT_V1_COMMIT = "eb7192d"
+REPETITIONS = 3
+
+
+def _git_output(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _load_phase_step(phase: str) -> tuple[dict, Path]:
+    phase_dir = ROOT / "phases" / phase
+    index = json.loads((phase_dir / "index.json").read_text(encoding="utf-8"))
+    step = next((item for item in index["steps"] if item.get("status") == "pending"), None)
+    if step is None:
+        raise RuntimeError(f"phase {phase} has no pending step")
+    return step, phase_dir / f"step{step['step']}.md"
+
+
+def _fixture_sha256(phase: str, step_path: Path) -> str:
+    phase_dir = ROOT / "phases" / phase
+    paths = [
+        ROOT / "AGENTS.md",
+        phase_dir / "README.md",
+        step_path,
+        ROOT / ".codex" / "project-profile.json",
+        ROOT / "docs" / "COMMANDS.md",
+    ]
+    digest = hashlib.sha256()
+    for path in paths:
+        relative = path.relative_to(ROOT).as_posix()
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _legacy_module(v1_commit: str):
+    source = _git_output("show", f"{v1_commit}:scripts/execute.py")
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", suffix=".py", prefix="legacy_execute_", delete=False
+    ) as file:
+        file.write(source)
+        module_path = Path(file.name)
+
+    spec = importlib.util.spec_from_file_location("legacy_execute_for_eval", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("legacy execute module could not be loaded")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        module_path.unlink(missing_ok=True)
+    module.ROOT = ROOT
+    return module
+
+
+def _build_v1_prompt(phase: str, step: dict, step_path: Path, v1_commit: str) -> str:
+    legacy = _legacy_module(v1_commit)
+    executor = legacy.StepExecutor(phase)
+    guardrails = executor._load_guardrails()
+    index = executor._read_json(executor._index_file)
+    context = executor._build_step_context(index)
+    command_context = executor._load_command_context()
+    preamble = executor._build_preamble(guardrails, context, command_context)
+    return preamble + step_path.read_text(encoding="utf-8")
+
+
+def _build_v2_prompt(phase: str, step: dict) -> str:
+    executor = StepExecutor(phase)
+    index = executor._read_json(executor._index_file)
+    guardrails = executor._load_guardrails()
+    context = executor._build_step_context(index)
+    command_context = executor._load_command_context()
+    return executor._build_preamble(
+        guardrails,
+        context,
+        command_context,
+        step=step,
+    )
+
+
+def _document_body_markers(phase: str) -> list[str]:
+    phase_dir = ROOT / "phases" / phase
+    paths = [ROOT / "AGENTS.md", phase_dir / "README.md"]
+    for path in (ROOT / "docs").glob("*.md"):
+        paths.append(path)
+    markers: list[str] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                markers.append(line.strip())
+                break
+    return markers
+
+
+def _contract_quality(prompt: str, phase: str, step: dict, step_path: Path) -> dict:
+    step_text = step_path.read_text(encoding="utf-8")
+    expected_paths = {
+        "AGENTS.md",
+        f"phases/{phase}/README.md",
+        f"phases/{phase}/{step_path.name}",
+        *StepExecutor._step_read_paths(step_text),
+    }
+    expected_commands = read_acceptance_commands(step_path)
+    required_hard_constraints = ("기존 테스트", "이 step에 명시된 작업만", "index.json")
+    step_definition = StepExecutor._section_text(step_text, "## 작업")
+    path_ok = all(
+        any(marker in prompt for marker in (f"`{path}`", path, f"/{path}"))
+        for path in expected_paths
+        if path != f"phases/{phase}/{step_path.name}"
+    )
+    step_definition_ok = not step_definition or step_definition in prompt
+    commands_ok = all(command in prompt for command in expected_commands)
+    constraints_ok = all(marker in prompt for marker in required_hard_constraints)
+    body_markers = _document_body_markers(phase)
+    body_free = not any(marker in prompt for marker in body_markers)
+    return {
+        "requiredPaths": sorted(expected_paths),
+        "acceptanceCommandsPreserved": commands_ok,
+        "hardConstraintsPreserved": constraints_ok,
+        "directReadPathsPreserved": path_ok,
+        "stepDefinitionPreserved": step_definition_ok,
+        "documentBodiesAbsent": body_free,
+        "contractQualityPass": path_ok and step_definition_ok and commands_ok and constraints_ok,
+        "progressiveDisclosurePass": body_free,
+    }
+
+
+def _codex_version() -> str | None:
+    try:
+        result = subprocess.run(
+            [resolve_codex_bin(), "--version"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return (result.stdout or result.stderr).strip().splitlines()[0] or None
+
+
+def evaluate(phase: str, v1_commit: str) -> dict:
+    step, step_path = _load_phase_step(phase)
+    v1_prompt = _build_v1_prompt(phase, step, step_path, v1_commit)
+    v2_prompt = _build_v2_prompt(phase, step)
+    fixture_sha = _fixture_sha256(phase, step_path)
+    v1_quality = _contract_quality(v1_prompt, phase, step, step_path)
+    v2_quality = _contract_quality(v2_prompt, phase, step, step_path)
+    repetitions = []
+    for repetition in range(1, REPETITIONS + 1):
+        repetitions.extend(
+            [
+                {
+                    "variant": "v1",
+                    "scenario": "EVAL-DOCS/EVAL-CODE prompt-contract proxy",
+                    "repetition": repetition,
+                    "promptChars": len(v1_prompt),
+                    "promptBytes": len(v1_prompt.encode("utf-8")),
+                    "quality": v1_quality,
+                },
+                {
+                    "variant": "v2",
+                    "scenario": "EVAL-DOCS/EVAL-CODE prompt-contract proxy",
+                    "repetition": repetition,
+                    "promptChars": len(v2_prompt),
+                    "promptBytes": len(v2_prompt.encode("utf-8")),
+                    "quality": v2_quality,
+                },
+            ]
+        )
+
+    v1_bytes = len(v1_prompt.encode("utf-8"))
+    v2_bytes = len(v2_prompt.encode("utf-8"))
+    return {
+        "scope": "prompt construction contract proxy; no Codex task was executed",
+        "baseCommit": v1_commit,
+        "v2Commit": _git_output("rev-parse", "HEAD"),
+        "fixtureSha256": fixture_sha,
+        "phase": phase,
+        "step": {"step": step["step"], "name": step["name"]},
+        "conditions": {
+            "os": platform.platform(),
+            "python": platform.python_version(),
+            "codex": _codex_version(),
+            "model": "not invoked",
+            "effort": "medium",
+            "sandbox": "not invoked",
+            "approvalPolicy": "not invoked",
+            "retryLimit": StepExecutor.MAX_RETRIES,
+            "setupIncluded": False,
+            "cacheState": "not applicable",
+            "repetitions": REPETITIONS,
+        },
+        "variants": {
+            "v1": {
+                "promptChars": len(v1_prompt),
+                "promptBytes": v1_bytes,
+                "quality": v1_quality,
+            },
+            "v2": {
+                "promptChars": len(v2_prompt),
+                "promptBytes": v2_bytes,
+                "quality": v2_quality,
+            },
+        },
+        "delta": {
+            "promptChars": len(v2_prompt) - len(v1_prompt),
+            "promptBytes": v2_bytes - v1_bytes,
+            "promptBytesReductionPercent": round((v1_bytes - v2_bytes) / v1_bytes * 100, 2),
+            "v2ContractQualityNoRegression": v2_quality["contractQualityPass"],
+            "v2ProgressiveDisclosurePass": v2_quality["progressiveDisclosurePass"],
+        },
+        "repetitions": repetitions,
+        "tokens": None,
+        "unavailableReason": "prompt proxy does not invoke codex exec and stores no prompt text",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--phase", default=DEFAULT_PHASE)
+    parser.add_argument("--v1-commit", default=DEFAULT_V1_COMMIT)
+    args = parser.parse_args(argv)
+    print(json.dumps(evaluate(args.phase, args.v1_commit), ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/execute.py
+++ b/scripts/execute.py
@@ -40,6 +40,10 @@ DEFAULT_CODEX_EFFORT = "medium"
 CODEX_BIN = resolve_codex_bin()
 
 
+class GuardrailReferenceError(RuntimeError):
+    """Raised when a file path required by the progressive prompt is invalid."""
+
+
 @contextlib.contextmanager
 def progress_indicator(label: str):
     """터미널 진행 표시기. with 문으로 사용하며 .elapsed 로 경과 시간을 읽는다."""
@@ -122,8 +126,12 @@ class StepExecutor:
         self._print_header()
         self._check_blockers()
         self._ensure_clean_worktree()
+        try:
+            guardrails = self._load_guardrails()
+        except GuardrailReferenceError as exc:
+            print(f"\n  ERROR: {exc}")
+            sys.exit(1)
         self._checkout_branch()
-        guardrails = self._load_guardrails()
         command_context = self._load_command_context()
         self._ensure_created_at()
         step_only = self._step_number is not None or self._next_step_only
@@ -250,55 +258,111 @@ class StepExecutor:
 
     # --- guardrails & context ---
 
+    def _project_root(self) -> Path:
+        return Path(getattr(self, "_root", ROOT))
+
     def _load_guardrails(self) -> str:
-        sections = []
-        agents_md = ROOT / "AGENTS.md"
-        if agents_md.exists():
-            sections.append(f"## 프로젝트 규칙 (AGENTS.md)\n\n{agents_md.read_text(encoding='utf-8')}")
         phase_dir = getattr(self, "_phase_dir", None)
-        phase_readme = phase_dir / "README.md" if phase_dir is not None else None
-        if phase_readme is not None and phase_readme.exists():
-            sections.append(
-                f"## 현재 Phase README ({getattr(self, '_phase_dir_name', phase_readme.parent.name)}/README.md)\n\n"
-                f"{phase_readme.read_text(encoding='utf-8')}"
+        if phase_dir is None:
+            return ""
+
+        entries: list[tuple[str, object]] = [("프로젝트 규칙", "AGENTS.md")]
+        phase_readme = phase_dir / "README.md"
+        phase_name = getattr(self, "_phase_dir_name", phase_readme.parent.name)
+        entries.append(("현재 Phase README", f"phases/{phase_name}/README.md"))
+
+        profile = checks.load_project_profile(self._project_root())
+        if "guardrailDocs" in profile:
+            profile_docs = profile.get("guardrailDocs")
+            if not isinstance(profile_docs, list):
+                raise GuardrailReferenceError(
+                    ".codex/project-profile.json의 guardrailDocs는 저장소 상대 경로 목록이어야 합니다."
+                )
+            if profile_docs:
+                selected_docs = profile_docs
+                selection_source = "guardrailDocs"
+            else:
+                selected_docs = self._referenced_doc_paths()
+                if not selected_docs:
+                    selected_docs = self._default_guardrail_doc_paths()
+                selection_source = "자동 선택"
+        else:
+            selected_docs = self._referenced_doc_paths()
+            if not selected_docs:
+                selected_docs = self._default_guardrail_doc_paths()
+            selection_source = "phase 문서 참조"
+
+        entries.extend((f"{selection_source} 경로", rel) for rel in selected_docs)
+        references: list[tuple[str, str]] = []
+        errors: list[str] = []
+        seen: set[str] = set()
+        for label, raw_path in entries:
+            normalized, error = self._validate_reference_path(raw_path, label=label)
+            if error:
+                errors.append(error)
+                continue
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            references.append((label, normalized))
+
+        if errors:
+            raise GuardrailReferenceError(
+                "guardrail 참조 경로 검증 실패:\n" + "\n".join(f"- {error}" for error in errors)
             )
 
-        # 첨부 문서 선택 우선순위:
-        # 1. .codex/project-profile.json의 guardrailDocs (명시 고정 목록)
-        # 2. phase README/step 문서가 참조하는 docs/*.md만 (기본 — 프롬프트 크기 통제)
-        # 3. 참조가 하나도 없으면 docs 전체 (안전 fallback)
-        profile_docs = checks.load_project_profile(ROOT).get("guardrailDocs")
-        if isinstance(profile_docs, list) and profile_docs:
-            for rel in profile_docs:
-                if not isinstance(rel, str):
-                    continue
-                doc = ROOT / rel
-                if doc.is_file():
-                    sections.append(f"## {rel}\n\n{doc.read_text(encoding='utf-8')}")
-            return "\n\n---\n\n".join(sections) if sections else ""
+        lines = [
+            "## 직접 읽어야 할 경로",
+            "",
+            "작업을 시작하기 전에 아래 경로를 저장소에서 직접 읽어라. "
+            "문서 본문은 이 prompt에 첨부되지 않습니다.",
+            "",
+        ]
+        lines.extend(f"- `{path}` ({label})" for label, path in references)
+        return "\n".join(lines)
 
-        referenced = self._referenced_doc_paths()
-        if referenced:
-            for rel in referenced:
-                sections.append(f"## {rel}\n\n{(ROOT / rel).read_text(encoding='utf-8')}")
-            sections.append(
-                "## 추가 문서\n\n"
-                "여기 첨부되지 않은 docs/*.md와 docs/adr/*.md는 필요할 때 직접 읽어라."
-            )
-            return "\n\n---\n\n".join(sections)
+    def _default_guardrail_doc_paths(self) -> list[str]:
+        """Return a small canonical document set without reading its contents into the prompt."""
+        defaults = (
+            "docs/PRD.md",
+            "docs/ARCHITECTURE.md",
+            "docs/ADR.md",
+            "docs/COMMANDS.md",
+            "docs/SCOPE_CHANGE_CHECKLIST.md",
+        )
+        root = self._project_root()
+        return [rel for rel in defaults if (root / rel).is_file()]
 
-        docs_dir = ROOT / "docs"
-        if docs_dir.is_dir():
-            for doc in sorted(docs_dir.glob("*.md")):
-                sections.append(f"## {doc.stem}\n\n{doc.read_text(encoding='utf-8')}")
-            adr_dir = docs_dir / "adr"
-            if adr_dir.is_dir():
-                for doc in sorted(adr_dir.glob("*.md")):
-                    sections.append(f"## adr/{doc.stem}\n\n{doc.read_text(encoding='utf-8')}")
-        return "\n\n---\n\n".join(sections) if sections else ""
+    def _validate_reference_path(self, raw_path: object, *, label: str) -> tuple[str | None, str | None]:
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            return None, f"{label}: 비어 있지 않은 저장소 상대 경로가 필요합니다."
+
+        raw = raw_path.strip().replace("\\", "/")
+        candidate_path = Path(raw)
+        if candidate_path.is_absolute():
+            return None, f"{label} `{raw_path}`: 저장소 상대 경로가 아닙니다."
+
+        root = self._project_root().resolve()
+        candidate = (root / candidate_path).resolve()
+        if not candidate.is_relative_to(root):
+            return None, f"{label} `{raw_path}`: 저장소 밖의 경로는 읽을 수 없습니다."
+        if not candidate.exists():
+            return None, f"{label} `{raw_path}`: 경로가 존재하지 않습니다."
+        if not candidate.is_file() and not candidate.is_dir():
+            return None, f"{label} `{raw_path}`: 파일 또는 디렉터리가 아닙니다."
+
+        try:
+            if candidate.is_file():
+                candidate.read_text(encoding="utf-8")
+            else:
+                next(candidate.iterdir(), None)
+        except (OSError, UnicodeError) as exc:
+            return None, f"{label} `{raw_path}`: 읽을 수 없습니다 ({exc})."
+
+        return candidate.relative_to(root).as_posix(), None
 
     def _referenced_doc_paths(self) -> list[str]:
-        """phase README와 step 문서가 참조하는 docs 경로(존재하는 것만)를 모은다."""
+        """phase 문서가 참조하는 docs 경로를 모은다; 존재 검사는 호출자가 담당한다."""
         phase_dir = getattr(self, "_phase_dir", None)
         if phase_dir is None or not phase_dir.is_dir():
             return []
@@ -308,15 +372,22 @@ class StepExecutor:
         for source in sources:
             if not source.exists():
                 continue
-            for rel in self.DOC_REFERENCE_RE.findall(source.read_text(encoding="utf-8")):
-                if rel in seen or not (ROOT / rel).is_file():
+            try:
+                content = source.read_text(encoding="utf-8")
+            except (OSError, UnicodeError) as exc:
+                rel_source = source.resolve().relative_to(self._project_root().resolve()).as_posix()
+                raise GuardrailReferenceError(
+                    f"guardrail 참조 소스 `{rel_source}`를 읽을 수 없습니다 ({exc})."
+                ) from exc
+            for rel in self.DOC_REFERENCE_RE.findall(content):
+                if rel in seen:
                     continue
                 seen.add(rel)
                 referenced.append(rel)
         return sorted(referenced)
 
     def _load_command_context(self) -> str:
-        selected = checks.collect_checks(ROOT, "manual")
+        selected = checks.collect_checks(self._project_root(), "manual")
         if not selected:
             return (
                 "## 프로젝트 검증 명령\n\n"
@@ -345,12 +416,100 @@ class StepExecutor:
             return ""
         return "## 이전 Step 산출물\n\n" + "\n".join(lines) + "\n\n"
 
+    @staticmethod
+    def _section_text(markdown: str, heading: str) -> str:
+        lines: list[str] = []
+        in_section = False
+        for raw in markdown.splitlines():
+            line = raw.strip()
+            if line.startswith("## "):
+                if in_section:
+                    break
+                in_section = line == heading
+                continue
+            if in_section:
+                lines.append(raw.rstrip())
+        return "\n".join(lines).strip()
+
+    @staticmethod
+    def _step_read_paths(markdown: str) -> list[str]:
+        section = StepExecutor._section_text(markdown, "## 읽어야 할 파일")
+        paths: list[str] = []
+        for raw in section.splitlines():
+            line = raw.strip()
+            if not line.startswith("-"):
+                continue
+            value = line[1:].strip()
+            if value.startswith("`") and "`" in value[1:]:
+                value = value[1 : value.find("`", 1)]
+            else:
+                value = value.split(maxsplit=1)[0] if value else ""
+            value = value.strip().replace("\\", "/").lstrip("/")
+            if value and value not in paths:
+                paths.append(value)
+        return paths
+
+    def _read_step_definition(self, step: dict) -> tuple[str, str]:
+        step_num = step.get("step", "?")
+        step_file = self._phase_dir / f"step{step_num}.md"
+        rel_path = f"phases/{self._phase_dir_name}/step{step_num}.md"
+        if not step_file.exists():
+            raise GuardrailReferenceError(f"현재 step 참조 `{rel_path}`: 경로가 존재하지 않습니다.")
+        try:
+            return rel_path, step_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise GuardrailReferenceError(
+                f"현재 step 참조 `{rel_path}`를 읽을 수 없습니다 ({exc})."
+            ) from exc
+
+    def _step_contract(self, step: dict) -> tuple[str, list[str], str, str, str]:
+        step_path, markdown = self._read_step_definition(step)
+        read_paths = [step_path, *self._step_read_paths(markdown)]
+        errors: list[str] = []
+        normalized_paths: list[str] = []
+        seen: set[str] = set()
+        for raw_path in read_paths:
+            normalized, error = self._validate_reference_path(raw_path, label="step 읽기 경로")
+            if error:
+                errors.append(error)
+                continue
+            if normalized not in seen:
+                seen.add(normalized)
+                normalized_paths.append(normalized)
+        if errors:
+            raise GuardrailReferenceError(
+                "step 참조 경로 검증 실패:\n" + "\n".join(f"- {error}" for error in errors)
+            )
+
+        objective = self._section_text(markdown, "## 작업")
+        acceptance = self._section_text(markdown, "## 인수 기준")
+        constraints = self._section_text(markdown, "## 금지사항")
+        return step_path, normalized_paths, objective, acceptance, constraints
+
+    @staticmethod
+    def _with_step_read_paths(guardrails: str, paths: list[str]) -> str:
+        result = guardrails.rstrip()
+        if "## 직접 읽어야 할 경로" not in result:
+            result = (
+                f"{result}\n\n" if result else ""
+            ) + "## 직접 읽어야 할 경로\n\n"
+        extras = [
+            f"- `{path}` (step 문서가 지정한 참조)"
+            for path in paths
+            if f"`{path}`" not in result
+        ]
+        if extras:
+            result = f"{result}\n" + "\n".join(extras)
+        return result
+
     def _build_preamble(
         self,
         guardrails: str,
         step_context: str,
         command_context: str = "",
         prev_error: Optional[str] = None,
+        *,
+        step: Optional[dict] = None,
     ) -> str:
         commit_example = self.FEAT_MSG.format(
             phase=self._phase_name, num="N", name="<step-name>"
@@ -361,15 +520,33 @@ class StepExecutor:
                 "\n## 이전 시도 실패 - 아래 에러를 반드시 참고하여 수정하라\n\n"
                 f"{prev_error}\n\n---\n\n"
             )
+        objective = ""
+        acceptance = ""
+        constraints = ""
+        if step is not None:
+            _, read_paths, objective, acceptance, constraints = self._step_contract(step)
+            guardrails = self._with_step_read_paths(guardrails, read_paths)
+
+        step_contract = ""
+        if step is not None:
+            step_contract = (
+                "## Objective\n\n"
+                f"Phase `{self._phase_name}` Step {step.get('step', '?')} `{step.get('name', 'unknown')}`\n\n"
+                f"{objective or '현재 step의 작업 목표는 step 파일을 직접 읽어 확인하라.'}\n\n"
+                "## Acceptance criteria\n\n"
+                f"{acceptance or '현재 step 파일의 인수 기준과 검증 명령을 직접 읽고 모두 통과시켜라.'}\n\n"
+            )
+            constraints = constraints or "- 현재 step 파일에 명시된 범위를 벗어나지 마라."
+            step_contract += f"## Hard constraints\n\n{constraints}\n\n"
         return (
             f"당신은 {self._project} 프로젝트의 개발자입니다. 아래 step을 수행하세요.\n\n"
             f"{guardrails}\n\n---\n\n"
-            f"{step_context}{retry_section}"
+            f"{step_contract}{step_context}{retry_section}"
             f"{command_context}"
-            "## 작업 규칙\n\n"
+            "## Hard constraints / 작업 규칙\n\n"
             "1. 이전 step에서 작성된 코드를 확인하고 일관성을 유지하라.\n"
-            "2. 이 step에 명시된 작업만 수행하라. 추가 기능이나 파일을 만들지 마라.\n"
-            "3. 기존 테스트를 깨뜨리지 마라.\n"
+            "2. 이 step에 명시된 작업만 수행하라. 미래 step 기능이나 추가 파일을 만들지 마라.\n"
+            "3. 기존 테스트를 깨뜨리지 말고 credential 값이나 secret을 prompt와 로그에 넣지 마라.\n"
             "4. AC(Acceptance Criteria)와 프로젝트 검증 명령을 직접 실행하라.\n"
             f"5. /phases/{self._phase_dir_name}/index.json의 해당 step status를 업데이트하라:\n"
             '   - AC 통과 -> "completed" + "summary" 필드에 이 step의 산출물을 한 줄로 요약\n'
@@ -389,7 +566,15 @@ class StepExecutor:
             print(f"  ERROR: {step_file} not found")
             sys.exit(1)
 
-        prompt = preamble + step_file.read_text(encoding="utf-8")
+        try:
+            step_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            print(f"  ERROR: 현재 step 참조 `{step_file}`를 읽을 수 없습니다 ({exc}).")
+            sys.exit(1)
+
+        # step 문서는 _build_preamble에서 필요한 섹션만 추려 전달한다.
+        # 전체 문서 본문을 다시 붙이면 progressive disclosure 계약을 깨뜨린다.
+        prompt = preamble
         cmd = codex_base_cmd(self._codex_effort)
         if self._unsafe:
             cmd.append("--dangerously-bypass-approvals-and-sandbox")
@@ -481,7 +666,17 @@ class StepExecutor:
         for attempt in range(1, self.MAX_RETRIES + 1):
             index = self._read_json(self._index_file)
             step_context = self._build_step_context(index)
-            preamble = self._build_preamble(guardrails, step_context, command_context, prev_error)
+            try:
+                preamble = self._build_preamble(
+                    guardrails,
+                    step_context,
+                    command_context,
+                    prev_error,
+                    step=step,
+                )
+            except GuardrailReferenceError as exc:
+                print(f"\n  ERROR: {exc}")
+                sys.exit(1)
 
             tag = f"Step {step_num}/{self._total - 1} ({done} done): {step_name}"
             if attempt > 1:

--- a/scripts/tests/test_execute.py
+++ b/scripts/tests/test_execute.py
@@ -64,7 +64,28 @@ def phase_dir(tmp_project):
     }
     (d / "index.json").write_text(json.dumps(index, indent=2, ensure_ascii=False))
     (d / "README.md").write_text("# Phase README\n\n현재 phase 목표")
-    (d / "step2.md").write_text("# Step 2: UI\n\nUI를 구현하세요.")
+    (d / "step2.md").write_text(
+        "\n".join(
+            [
+                "# Step 2: UI",
+                "",
+                "## 읽어야 할 파일",
+                "- /docs/arch.md",
+                "",
+                "## 작업",
+                "UI를 구현하세요.",
+                "",
+                "## 인수 기준",
+                "```bash",
+                "python -m pytest",
+                "```",
+                "",
+                "## 금지사항",
+                "- credential 값이나 secret을 prompt에 넣지 마라.",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
     return d
 
@@ -155,20 +176,28 @@ class TestJsonHelpers:
 # ---------------------------------------------------------------------------
 
 class TestLoadGuardrails:
-    def test_loads_agents_md_and_docs(self, executor, tmp_project):
+    def test_loads_reference_paths_without_document_bodies(self, executor, tmp_project):
         with patch.object(ex, "ROOT", tmp_project):
             result = executor._load_guardrails()
-        assert "# Rules" in result
-        assert "rule one" in result
-        assert "# Architecture" in result
-        assert "# Guide" in result
+        assert "AGENTS.md" in result
+        assert "phases/0-mvp/README.md" in result
+        assert "docs/arch.md" in result
+        assert "# Rules" not in result
+        assert "rule one" not in result
+        assert "# Architecture" not in result
+        assert "Some content" not in result
 
-    def test_sections_separated_by_divider(self, executor, tmp_project):
+    def test_prompt_explains_direct_read_boundary(self, executor, tmp_project):
         with patch.object(ex, "ROOT", tmp_project):
             result = executor._load_guardrails()
-        assert "---" in result
+        assert "직접 읽어야 할 경로" in result
+        assert "본문은 이 prompt에 첨부되지 않습니다" in result
 
     def test_docs_sorted_alphabetically(self, executor, tmp_project):
+        (executor._phase_dir / "step2.md").write_text(
+            "# Step 2\n\n## 읽어야 할 파일\n- /docs/guide.md\n- /docs/arch.md\n",
+            encoding="utf-8",
+        )
         with patch.object(ex, "ROOT", tmp_project):
             result = executor._load_guardrails()
         arch_pos = result.index("arch")
@@ -179,31 +208,40 @@ class TestLoadGuardrails:
         adr_dir = tmp_project / "docs" / "adr"
         adr_dir.mkdir()
         (adr_dir / "0001-test.md").write_text("# Split ADR")
+        (executor._phase_dir / "step2.md").write_text(
+            "# Step 2\n\n## 읽어야 할 파일\n- /docs/adr/0001-test.md\n",
+            encoding="utf-8",
+        )
         with patch.object(ex, "ROOT", tmp_project):
             result = executor._load_guardrails()
         assert "adr/0001-test" in result
-        assert "Split ADR" in result
+        assert "Split ADR" not in result
 
     def test_loads_phase_readme(self, executor, tmp_project):
         with patch.object(ex, "ROOT", tmp_project):
             result = executor._load_guardrails()
         assert "현재 Phase README" in result
-        assert "현재 phase 목표" in result
+        assert "phases/0-mvp/README.md" in result
+        assert "현재 phase 목표" not in result
 
     def test_no_agents_md(self, executor, tmp_project):
         (tmp_project / "AGENTS.md").unlink()
         with patch.object(ex, "ROOT", tmp_project):
-            result = executor._load_guardrails()
-        assert "AGENTS.md" not in result
-        assert "Architecture" in result
+            with pytest.raises(ex.GuardrailReferenceError, match="AGENTS.md"):
+                executor._load_guardrails()
 
     def test_no_docs_dir(self, executor, tmp_project):
         import shutil
         shutil.rmtree(tmp_project / "docs")
+        (executor._phase_dir / "step2.md").write_text(
+            "# Step 2: UI\n\n## 작업\nUI를 구현하세요.",
+            encoding="utf-8",
+        )
         with patch.object(ex, "ROOT", tmp_project):
             result = executor._load_guardrails()
-        assert "Rules" in result
-        assert "Architecture" not in result
+        assert "AGENTS.md" in result
+        assert "docs/" not in result
+        assert "Rules" not in result
 
     def test_empty_project(self, tmp_path):
         with patch.object(ex, "ROOT", tmp_path):
@@ -224,11 +262,13 @@ class TestLoadGuardrails:
         with patch.object(ex, "ROOT", tmp_project):
             result = executor._load_guardrails()
 
-        assert "# Architecture" in result
-        assert "# Guide" not in result
+        assert "docs/arch.md" in result
+        assert "docs/guide.md" not in result
+        assert "# Architecture" not in result
+        assert "Some content" not in result
         assert "직접 읽어라" in result
-        assert "# Rules" in result
-        assert "# Phase README" in result
+        assert "# Rules" not in result
+        assert "# Phase README" not in result
 
     def test_guardrail_docs_profile_overrides_references(self, executor, tmp_project):
         (executor._phase_dir / "step2.md").write_text(
@@ -244,8 +284,53 @@ class TestLoadGuardrails:
         with patch.object(ex, "ROOT", tmp_project):
             result = executor._load_guardrails()
 
-        assert "# Guide" in result
+        assert "docs/guide.md" in result
+        assert "docs/arch.md" not in result
+        assert "# Guide" not in result
+
+    def test_empty_guardrail_docs_uses_phase_references(self, executor, tmp_project):
+        (executor._phase_dir / "step2.md").write_text(
+            "# Step 2: UI\n\ndocs/arch.md 계약을 따라 UI를 구현하세요.",
+            encoding="utf-8",
+        )
+        codex_dir = tmp_project / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "project-profile.json").write_text(
+            json.dumps({"guardrailDocs": []}),
+            encoding="utf-8",
+        )
+
+        with patch.object(ex, "ROOT", tmp_project):
+            result = executor._load_guardrails()
+
+        assert "docs/arch.md" in result
         assert "# Architecture" not in result
+
+    def test_missing_profile_reference_is_diagnosed(self, executor, tmp_project):
+        codex_dir = tmp_project / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "project-profile.json").write_text(
+            json.dumps({"guardrailDocs": ["docs/missing.md"]}),
+            encoding="utf-8",
+        )
+
+        with patch.object(ex, "ROOT", tmp_project):
+            with pytest.raises(ex.GuardrailReferenceError, match="docs/missing.md"):
+                executor._load_guardrails()
+
+    def test_unreadable_profile_reference_is_diagnosed(self, executor, tmp_project):
+        secret_doc = tmp_project / "docs" / "secret.md"
+        secret_doc.write_bytes(b"\xff\xfe")
+        codex_dir = tmp_project / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "project-profile.json").write_text(
+            json.dumps({"guardrailDocs": ["docs/secret.md"]}),
+            encoding="utf-8",
+        )
+
+        with patch.object(ex, "ROOT", tmp_project):
+            with pytest.raises(ex.GuardrailReferenceError, match="docs/secret.md"):
+                executor._load_guardrails()
 
 
 # ---------------------------------------------------------------------------
@@ -349,6 +434,23 @@ class TestBuildPreamble:
         result = executor._build_preamble("", "", "## 프로젝트 검증 명령\n\n```bash\npython -m pytest\n```\n")
         assert "프로젝트 검증 명령" in result
         assert "python -m pytest" in result
+
+    def test_includes_step_contract_without_full_step_document(self, executor):
+        result = executor._build_preamble(
+            "## 직접 읽어야 할 경로\n\n- `AGENTS.md`\n- `docs/arch.md`",
+            "## 이전 Step 산출물\n\n- Step 0: done\n",
+            "## 프로젝트 검증 명령\n\n```bash\npython -m pytest\n```\n",
+            step={"step": 2, "name": "ui"},
+        )
+
+        assert "## Objective" in result
+        assert "UI를 구현하세요." in result
+        assert "## Acceptance criteria" in result
+        assert "python -m pytest" in result
+        assert "## Hard constraints" in result
+        assert "credential 값이나 secret을 prompt에 넣지 마라." in result
+        assert "# Phase README" not in result
+        assert "현재 phase 목표" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -593,7 +695,7 @@ class TestInvokeCodex:
         assert "--dangerously-bypass-approvals-and-sandbox" not in cmd
         assert cmd[-1] == "-"
         assert "PREAMBLE" in mock_run.call_args.kwargs["input"]
-        assert "UI를 구현하세요" in mock_run.call_args.kwargs["input"]
+        assert "UI를 구현하세요" not in mock_run.call_args.kwargs["input"]
 
     def test_codex_effort_adds_codex_config(self, executor):
         executor._codex_effort = "high"
@@ -634,6 +736,53 @@ class TestInvokeCodex:
         assert data["step"] == 2
         assert data["name"] == "ui"
         assert data["exitCode"] == 0
+        assert "PREAMBLE" not in json.dumps(data, ensure_ascii=False)
+
+    def test_prompt_and_output_do_not_include_document_body_or_secret(self, executor, tmp_project):
+        secret_doc = tmp_project / "docs" / "secret.md"
+        secret_doc.write_text("SECRET_SENTINEL_VALUE", encoding="utf-8")
+        codex_dir = tmp_project / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "project-profile.json").write_text(
+            json.dumps({"guardrailDocs": ["docs/secret.md"]}),
+            encoding="utf-8",
+        )
+        prompt = executor._build_preamble(
+            executor._load_guardrails(),
+            "",
+            "",
+            step={"step": 2, "name": "ui"},
+        )
+        mock_result = MagicMock(returncode=0, stdout="agent output", stderr="")
+
+        with patch("subprocess.run", return_value=mock_result):
+            executor._invoke_codex({"step": 2, "name": "ui"}, prompt)
+
+        saved = (executor._phase_dir / "step2-output.json").read_text(encoding="utf-8")
+        assert "SECRET_SENTINEL_VALUE" not in prompt
+        assert "SECRET_SENTINEL_VALUE" not in saved
+        assert "# Architecture" not in prompt
+        assert "Some content" not in prompt
+
+    def test_run_stops_before_codex_when_reference_is_missing(self, executor, tmp_project, capsys):
+        codex_dir = tmp_project / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "project-profile.json").write_text(
+            json.dumps({"guardrailDocs": ["docs/missing.md"]}),
+            encoding="utf-8",
+        )
+        calls = []
+        executor._ensure_clean_worktree = lambda: calls.append("clean")
+        executor._checkout_branch = lambda: calls.append("checkout")
+        executor._execute_one_step = lambda *args: calls.append("codex")
+
+        with pytest.raises(SystemExit) as exc_info:
+            with patch.object(ex, "ROOT", tmp_project):
+                executor.run()
+
+        assert exc_info.value.code == 1
+        assert calls == ["clean"]
+        assert "docs/missing.md" in capsys.readouterr().out
 
     def test_nonexistent_step_file_exits(self, executor):
         step = {"step": 99, "name": "nonexistent"}
@@ -682,6 +831,7 @@ class TestVerifyAcceptance:
         (executor._phase_dir / "step2.md").write_text(body, encoding="utf-8")
 
     def test_no_acceptance_section_passes(self, executor):
+        (executor._phase_dir / "step2.md").write_text("# Step 2: UI\n\nUI를 구현하세요.", encoding="utf-8")
         assert executor._verify_acceptance(2) is None
 
     def test_runs_commands_and_passes(self, executor):


### PR DESCRIPTION
## 변경 내용
- `execute.py`의 guardrail prompt를 문서 본문 첨부에서 objective, 직접 읽을 경로, acceptance criteria, hard constraints, 이전 summary 중심으로 전환했습니다.
- `guardrailDocs`를 경로 선택 입력으로 유지하고, AGENTS/phase/profile/step 참조의 누락·판독 불가를 Codex 호출 전에 진단합니다.
- PR #25의 평가 계약에 맞춘 3회 prompt 계약 proxy와 결과를 추가했습니다. phase Step 2 상태도 완료로 기록했습니다.
- 설정·명령·Harness 가이드와 changelog를 새 계약에 맞게 갱신했습니다.

Closes #15

## 범위
- Step 3의 schema v2, SDK, worktree, DAG/동시성은 포함하지 않았습니다.
- PR26의 `shell_environment_policy` 최소 상속 계약과 `codex_common.py`/autopilot 실행 경로는 유지했습니다.

## 검증
- `uv run --with pytest python -X utf8 -m pytest scripts` — 186 passed
- `uv run --with pytest python -X utf8 scripts/doctor.py --template` — passed
- `uv run --with pytest python -X utf8 scripts/checks.py --docs-check-config phases/harness-v2-modernization/docs-checks.json --docs-check` — passed
- `uv run --with pytest python -X utf8 -m compileall -q scripts` — passed
- `git diff --check` — passed
- `scripts/checks.py --stage manual`/`final` — 기존 템플릿의 빈 `test`·`build` 설정으로 expected failure

## 평가
- v1 기준: `eb7192d`, v2 구현: `25787d2`
- 평가 도구 최종 commit: `9904ec7`
- fixture SHA-256: `9a6a50f1e7ee67595859c166a10c460012b224f34e5c543ce34fb3ae804c1644`
- v1 → v2: 26,066 → 3,814 UTF-8 bytes, 85.37% 감소
- 계약 품질 3/3 유지, 문서 본문 부재 v2 3/3
- Codex 작업을 실행하지 않은 구조적 proxy이므로 task 성공률·wall time·token 개선으로 주장하지 않았습니다. token은 `null`과 사유를 기록했습니다.

## 남은 위험
- 실제 EVAL-DOCS/EVAL-CODE 작업 성공률, CI, hard gate는 Step 10 release eval에서 별도로 측정해야 합니다.