### PR TITLE
feat: outcome 기반 task schema v2와 v1 호환 추가

### DIFF
--- a/.agents/skills/harness/SKILL.md
+++ b/.agents/skills/harness/SKILL.md
@@ -111,13 +111,50 @@ python scripts/checks.py --stage manual
 }
 ```
 
+phase index의 전체 v1/v2 계약은 루트 [`docs/TASK_SCHEMA.md`](../../../docs/TASK_SCHEMA.md)에
+둔다. 기존 파일을 보존해야 하므로 이 skill의 기본 예시는 v1 `steps[]` 형식이며,
+`phases/0-example/index.json`은 변경하지 않는 호환 fixture다. outcome 중심 task가
+필요한 새 phase는 다음 v2 모양을 사용한다:
+
+```json
+{
+  "schemaVersion": 2,
+  "project": "<프로젝트명>",
+  "phase": "<작업명>",
+  "tasks": [
+    {
+      "id": "api-layer",
+      "objective": "사용자가 확인할 결과를 만든다.",
+      "dependsOn": [],
+      "issue": 123,
+      "risk": "medium",
+      "status": "pending"
+    }
+  ]
+}
+```
+
+v1은 `steps[].step`, `steps[].name`, `steps[].status`를 사용하고, v2는
+`id`·`objective`·`status`를 필수로 하며 `dependsOn`·`issue`·`risk`를 선택으로
+둔다. 두 형식의 status는 `pending`, `completed`, `error`, `blocked`로 같다.
+`scripts/task_schema.py`가 형식을 구분하고 필수 필드, 타입, 중복 id, self/unknown
+dependency를 path/reason과 함께 Codex 호출 전에 검증한다. v2의 `dependsOn`은 이
+단계에서 reference metadata이며 list order를 바꾸지 않는다. ready set, cycle,
+DAG scheduler와 parallelism은 후속 #22 범위다.
+
+validator가 v2 task에 노출하는 배열 위치 `step`과 id 기반 `name`은 현재
+serial executor와 `stepN.md`를 연결하기 위한 메모리 alias다. 파일을 저장할 때
+`tasks[]` 원형을 유지하며 v1에 v2 필드를 추가하지 않는다. v1→v2 변환은 원본
+백업, dry-run, 검증과 사용자 승인을 포함한 별도 opt-in 작업으로만 수행한다.
+
 규칙:
 
+- 위 v1/v2 discriminator와 필드 규칙을 지킨다.
 - `project`: 프로젝트 이름이며 보통 `AGENTS.md`에서 가져온다.
 - `phase`: 디렉터리 이름과 일치하는 작업 이름이다.
-- `steps[].step`: 0부터 시작하는 순번이다.
-- `steps[].name`: kebab-case slug다.
-- `steps[].status`: 초기값은 `pending`이다.
+- v1 `steps[].step`: 0부터 시작하는 순번이다.
+- v1 `steps[].name`: kebab-case slug다.
+- v1/v2 `status`: 초기값은 `pending`이다.
 
 상태 필드:
 
@@ -257,8 +294,9 @@ python scripts/autopilot.py {작업명} --max-review-fixes 2  # phase 전체 구
 python scripts/autopilot.py {작업명} --dry-run --max-steps 1
 ```
 
-`scripts/execute.py`는 브랜치 생성, `AGENTS.md`·phase·관련 문서의 직접 읽기 경로
-검증, 현재 step의 objective/acceptance criteria/hard constraints와 완료된 단계의
+`scripts/execute.py`는 phase index를 `scripts/task_schema.py`로 먼저 검증한 뒤
+브랜치 생성, `AGENTS.md`·phase·관련 문서의 직접 읽기 경로 검증, 현재 step의
+objective/acceptance criteria/hard constraints와 완료된 단계의
 `summary` context 전달, 재시도 피드백, 코드 변경과 메타데이터의 2단계 커밋,
 completed 보고 후 인수 기준 재검증, 타임스탬프 기록, 선택적 push를 처리한다.
 문서 본문은 prompt에 첨부하지 않고 Codex가 저장소에서 직접 읽는다.
@@ -272,4 +310,4 @@ completed 보고 후 인수 기준 재검증, 타임스탬프 기록, 선택적 
 
 phase별 범위 규칙이 필요하면 `phases/{작업명}/scope-rules.json`에 `extraForbidden` 또는 `allowedScopeMessages`를 추가한다. 전역 규칙은 `.codex/scope-rules.json`에 둔다. 템플릿 스크립트에 제품별 금지 키워드를 추가하지 않는다.
 
-복구가 필요하면 `phases/{작업명}/index.json`에서 실패 또는 blocked 상태의 단계를 다시 `pending`으로 바꾸고, `error_message` 또는 `blocked_reason`을 제거한 뒤 원인을 해결하고 페이즈를 다시 실행한다.
+복구가 필요하면 `phases/{작업명}/index.json`에서 실패 또는 blocked 상태의 단계를 다시 `pending`으로 바꾸고, `error_message` 또는 `blocked_reason`을 제거한 뒤 원인을 해결하고 페이즈를 다시 실행한다. v1/v2 index의 validation 오류는 path/reason과 함께 Codex 호출 전에 중단되며, 기존 phase 파일은 자동 migration하지 않는다.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -35,6 +35,13 @@ description: "Codex가 이 Harness 기반 프로젝트의 변경사항을 AGENTS
 3. 테스트 커버리지: 새로운 동작에 적절한 테스트가 있거나, 테스트가 필요 없는 명확한 이유가 있는가?
 4. 핵심 규칙: 변경사항이 `AGENTS.md`의 CRITICAL 규칙을 위반하지 않는가?
 5. 빌드 준비 상태: `docs/COMMANDS.md`의 빌드, 린트, 테스트 명령을 로컬에서 실행할 수 있을 때 통과하는가?
+6. task schema: `phases/0-example/index.json`의 v1 원형이 유지되고, v2 변경은
+   `docs/TASK_SCHEMA.md`의 `id`·`objective`·`dependsOn`·`issue`·`risk` 및 공통
+   status 계약을 따르는가?
+7. pre-Codex safety: 중복 id, missing/self dependency, 필수 필드·타입·status 오류가
+   Codex/GitHub 호출 전에 파일 및 필드 경로와 reason으로 거부되는가?
+8. scope boundary: v2 alias가 저장 시 v1/v2 원형을 바꾸지 않고, #22의 DAG
+   scheduler·ready set·cycle 처리·parallelism이나 자동 migration을 선행하지 않는가?
 
 ### 출력
 
@@ -46,6 +53,8 @@ description: "Codex가 이 Harness 기반 프로젝트의 변경사항을 AGENTS
 | 기술 스택 준수 | 통과/실패 | {상세} |
 | 테스트 존재 | 통과/실패 | {상세} |
 | CRITICAL 규칙 | 통과/실패 | {상세} |
+| task schema와 pre-Codex 검증 | 통과/실패 | {v1/v2 contract, path/reason 오류, 실행 전 차단} |
+| 후속 범위 격리 | 통과/실패 | {DAG/parallel/migration 선행 여부} |
 | 빌드 가능 | 통과/실패 | {상세} |
 
 어떤 항목이라도 실패하면 파일 경로, 구체적인 문제, 수정 방안을 포함한다. 의존성이 없어서 검사를 실행하지 못한 경우에는 빌드 행에 그 사실을 명확히 적는다.

--- a/.codex/project-profile.json
+++ b/.codex/project-profile.json
@@ -1,6 +1,6 @@
 {
   "projectName": "<project-name>",
-  "templateVersion": "2026.09.04",
+  "templateVersion": "2026.09.04.1",
   "profile": "mixed",
   "guardMode": "soft",
   "commands": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 형식, doctor 검사 등)를 먼저 확인합니다. 절차는
 [guides/UPGRADE.md](guides/UPGRADE.md)를 따릅니다.
 
+## 2026.09.04.1
+
+### Added
+- `scripts/task_schema.py`와 `docs/TASK_SCHEMA.md`를 추가해 outcome task v2의
+  `id`, `objective`, `dependsOn`, `issue`, `risk` 계약과 v1 `steps[]` 호환을
+  정의했습니다.
+- v2 예제 phase, pre-Codex schema validation, duplicate/dependency/type/status
+  오류 테스트를 추가했습니다. v1→v2 자동 migration과 DAG/parallel 실행은
+  포함하지 않습니다.
+
 ## 2026.09.04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -88,13 +88,18 @@ python scripts/doctor.py --instance
   `TEMPLATE_VERSION`(`scripts/codex_common.py`)과 다름
 - `test` 또는 `build` 명령이 `docs/COMMANDS.md`와 project profile 양쪽에서 준비되지 않음
 - `git core.hooksPath`가 `.githooks`로 설정되어 있지 않음
+- phase-local `index.json`의 task schema가 깨져 있음
 
 ## ② 설계 — phase/step 나누기
 
 doctor가 통과한 뒤 Plan Mode에서 Harness skill로 phase/step 설계안을 만듭니다.
 프롬프트는 [guides/PROMPTS.md](guides/PROMPTS.md)의 "운영: phase/step 설계"를
 사용합니다. 설계안을 확정하면 MVP가 `phases/{phase}/README.md`, `index.json`,
-`stepN.md`로 나뉩니다.
+`stepN.md`로 나뉩니다. `index.json`은 기존 v1 `steps[]`와 outcome 중심 v2
+`tasks[]`를 지원합니다. 두 형식의 필드와 migration 경계는
+[docs/TASK_SCHEMA.md](docs/TASK_SCHEMA.md)에 있고, 실행 가능한 예시는
+[phases/0-example/](phases/0-example/)와 [phases/0-example-v2/](phases/0-example-v2/)
+에서 확인할 수 있습니다.
 
 ## ③ 실행
 
@@ -108,7 +113,9 @@ python scripts/execute.py {phase-name} --push           # 실행 후 push
 
 ### autopilot.py — step별 PR 루프
 
-실행 전 아래 사전 조건을 먼저 확인합니다.
+실행 전 아래 사전 조건을 먼저 확인합니다. v1/v2 phase index는 GitHub 인증이나
+Codex 호출 전에 공통 validator로 확인하며, v2의 `dependsOn`은 현재 실행 순서를
+바꾸지 않는 참조 메타데이터입니다.
 
 - 문서와 phase 파일 변경이 별도 commit으로 완료되어 있음
 - `git status --short`가 비어 있는 clean worktree 상태임
@@ -148,13 +155,13 @@ autopilot은 step마다 아래 루프를 반복합니다.
 | 영역 | 경로 | 역할 |
 | --- | --- | --- |
 | 규칙 | `AGENTS.md` | Codex가 따르는 100줄 안팎의 프로젝트 운영 규칙 |
-| 프로젝트 문서 | `docs/PRD.md`, `docs/ARCHITECTURE.md`, `docs/ADR.md`, `docs/adr/`, `docs/COMMANDS.md`, `docs/SCOPE_CHANGE_CHECKLIST.md` | MVP 범위, 구조, 기술 결정, 검증 명령, 범위 변경 체크리스트 |
+| 프로젝트 문서 | `docs/PRD.md`, `docs/ARCHITECTURE.md`, `docs/ADR.md`, `docs/adr/`, `docs/COMMANDS.md`, `docs/SCOPE_CHANGE_CHECKLIST.md`, `docs/TASK_SCHEMA.md` | MVP 범위, 구조, 기술 결정, 검증 명령, 범위 변경과 phase task schema |
 | 가이드 | `guides/PROMPTS.md`, `guides/CONFIGURATION.md`, `guides/UPGRADE.md` | 프롬프트 모음, 설정 레퍼런스, 업그레이드 절차 |
 | Codex 설정 | `.codex/` | hook 설정, project profile, scope rules |
 | Hook | `.githooks/pre-commit`, `.codex/hooks/` | 커밋 전 검증, cross-platform hook wrapper |
 | Skill | `.agents/skills/harness`, `.agents/skills/review` | phase/step 설계·실행, 문서 기준 자체 리뷰 워크플로우 |
-| 스크립트 | `scripts/`, `scripts/tests/` | `execute.py`, `autopilot.py`, `checks.py`, `doctor.py`, `guard.py`, `upgrade.py`, `codex_common.py`, Harness 스크립트 테스트 |
-| 작업 공간 | `phases/`, `issues/`, `archive/` | phase 문서(예시: `phases/0-example/`), 실패 기록, 직전 MVP 요약 |
+| 스크립트 | `scripts/`, `scripts/tests/` | `execute.py`, `autopilot.py`, `checks.py`, `doctor.py`, `task_schema.py`, `guard.py`, `upgrade.py`, `codex_common.py`, Harness 스크립트 테스트 |
+| 작업 공간 | `phases/`, `issues/`, `archive/` | v1/v2 phase 문서(예시: `phases/0-example/`, `phases/0-example-v2/`), 실패 기록, 직전 MVP 요약 |
 | CI | `.github/workflows/template-ci.yml` | macOS/Linux/Windows 템플릿 검증 (인스턴스에는 복사하지 않음) |
 | 메타 | `LICENSE`, `CHANGELOG.md` | MIT 라이선스, `templateVersion` 기준 변경 내역 |
 

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -8,3 +8,4 @@
 ## ADR 목록
 - [ADR-0001: Harness Step PR Workflow](adr/0001-step-pr-workflow.md)
 - [ADR-0002: Codex subprocess 환경 상속 최소화](adr/0002-minimize-codex-environment.md)
+- [ADR-0003: Outcome task schema v2와 v1 호환](adr/0003-outcome-task-schema-v2.md)

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -25,6 +25,25 @@ stage에서 `test`와 `build`는 필수 gate입니다. 둘 중 하나라도 비�
 | phase-step | `python scripts/execute.py <phase-name> --next-step-only` | no | 다음 pending step만 실행 |
 | autopilot | `python scripts/autopilot.py <phase-name> --max-review-fixes 2` | no | phase 전체 구현 시 권장. step별 PR 생성, 자체 리뷰, 이슈 기록, 자동 병합 루프 |
 
+## Phase index schema 검증
+
+`phases/{phase}/index.json`은 [`TASK_SCHEMA.md`](TASK_SCHEMA.md)의 v1 `steps[]`와
+v2 `tasks[]` 계약을 따릅니다. `execute.py`와 `autopilot.py`는 공통 validator를
+통해 필수 필드, 공통 status, 중복 id와 dependency reference를 Codex 호출 전에
+확인합니다. v2의 `dependsOn`은 현재 직렬 list-order를 바꾸지 않습니다.
+
+템플릿의 v1/v2 예시와 companion 문서는 다음으로 확인합니다.
+
+```bash
+python scripts/doctor.py --template
+python -m pytest scripts
+```
+
+이 검증은 기존 `phases/0-example/index.json`을 v1 그대로 읽는지와
+`phases/0-example-v2/index.json`의 outcome 필드를 함께 확인합니다. 자동 migration은
+없으며, v1을 v2로 바꾸는 작업은 원본 백업과 사용자 승인 뒤 별도 opt-in으로
+수행해야 합니다. DAG ready-set, cycle 처리와 병렬 실행은 후속 #22 범위입니다.
+
 ## Harness 운영 옵션
 
 Codex 호출은 프롬프트를 stdin으로 전달해 긴 phase 문서에서 argv 길이 제한을 피합니다.

--- a/docs/SCOPE_CHANGE_CHECKLIST.md
+++ b/docs/SCOPE_CHANGE_CHECKLIST.md
@@ -42,6 +42,7 @@
 | `docs/ARCHITECTURE.md` | 모듈 구조, 데이터 흐름, 외부 의존성, 경계, 테스트 전략 |
 | `docs/ADR.md`, `docs/adr/{NNNN}-*.md` | 새 결정 ADR 추가, 인덱스 연결, 이전 ADR과의 관계 |
 | `docs/COMMANDS.md` | 활성 명령, 새 검증 명령, 폐기된 명령 제거 |
+| `docs/TASK_SCHEMA.md` | phase index v1/v2 필드, status, validation과 migration 경계 |
 | `AGENTS.md` | 목표/기술 스택 문구, CRITICAL 규칙, 디렉터리 규칙이 새 범위와 충돌하지 않는지 |
 
 API 명세, DB 스키마, 화면 설계, 공유/배포 가이드 같은 프로젝트 전용 문서를
@@ -64,7 +65,7 @@ API 명세, DB 스키마, 화면 설계, 공유/배포 가이드 같은 프로�
 | --- | --- |
 | `phases/index.json` | 새 phase dir 추가와 상태 |
 | `phases/{phase}/README.md` | phase 목표, 작업/제외 범위, step 목록, 완료 기준, 검증 명령 |
-| `phases/{phase}/index.json` | step 순서, 이름, 상태 |
+| `phases/{phase}/index.json` | v1 `steps[]` 또는 v2 `tasks[]`의 순서, 필드, 상태와 dependency reference |
 | `phases/{phase}/step{N}.md` | 읽어야 할 파일, 작업, 인수 기준, 검증 절차, 금지사항 |
 | `phases/{phase}/docs-checks.json` | final stage에서 검증할 `required`/`finalRequired`/`forbidden` 마커 |
 
@@ -78,6 +79,7 @@ API 명세, DB 스키마, 화면 설계, 공유/배포 가이드 같은 프로�
 | 파일 | 수정하는 경우 |
 | --- | --- |
 | `scripts/checks.py` | docs-check 엔진, stage 처리, 명령 감지 자체가 바뀔 때 |
+| `scripts/task_schema.py` | phase index schema, 정규화 또는 pre-Codex validation이 바뀔 때 |
 | `scripts/execute.py` | branch/commit/final 검증 같은 phase 실행 workflow가 바뀔 때 |
 | `scripts/autopilot.py` | PR 생성, 자체 리뷰, issue 기록, merge loop workflow가 바뀔 때 |
 | `scripts/tests/test_*.py` | 위 스크립트 동작을 바꾼 경우 |

--- a/docs/TASK_SCHEMA.md
+++ b/docs/TASK_SCHEMA.md
@@ -1,0 +1,111 @@
+# Phase task schema
+
+이 문서는 `phases/{phase}/index.json`의 task 계약과 v1/v2 호환 규칙의
+source of truth다. 현재 실행기는 모든 입력을 검증한 뒤 배열 순서대로 한 번에
+하나의 task를 처리한다.
+
+## 형식 판별
+
+| 형식 | 판별 기준 | 저장 컨테이너 |
+| --- | --- | --- |
+| v1 | `steps`가 있고 `tasks`가 없음. 기존 파일에는 `schemaVersion`이 없어도 된다 | `steps[]` |
+| v2 | `schemaVersion: 2`와 `tasks` | `tasks[]` |
+
+v1을 명시적으로 구분하려면 `schemaVersion: 1`을 사용할 수 있다. `schemaVersion`이
+없고 `tasks`만 있는 입력도 v2로 읽을 수 있지만, 새 파일은 `schemaVersion: 2`를
+기록한다. `steps`와 `tasks`를 함께 두거나 marker와 컨테이너가 불일치하면
+거부한다.
+
+## 공통 상태
+
+v1과 v2는 같은 상태 집합을 사용한다.
+
+`pending` · `completed` · `error` · `blocked`
+
+실행기가 기록하는 `summary`, `error_message`, `blocked_reason`과 상태별 timestamp
+필드는 lifecycle 필드로 보존된다. `project`, `phase`, `created_at`, `completed_at`는
+기존 phase 기록과 함께 유지한다.
+
+## v1 계약
+
+기존 v1 입력의 최소 형태는 다음과 같다.
+
+```json
+{
+  "project": "<프로젝트명>",
+  "phase": "0-example",
+  "steps": [
+    { "step": 0, "name": "project-setup", "status": "pending" }
+  ]
+}
+```
+
+`step`은 0 이상 정수, `name`은 비어 있지 않은 문자열, `status`는 공통 상태 중
+하나여야 한다. 기존 v1 phase 파일에는 v2 필드를 추측해 추가하지 않으며,
+`phases/0-example/index.json`은 호환 fixture로 유지한다.
+
+## v2 계약
+
+v2 task는 다음 필드를 사용한다.
+
+| 필드 | 구분 | 타입과 규칙 |
+| --- | --- | --- |
+| `id` | 필수 | 비어 있지 않은 문자열. phase 안에서 유일해야 한다 |
+| `objective` | 필수 | 비어 있지 않은 결과 목표 문자열 |
+| `status` | 필수 | `pending`, `completed`, `error`, `blocked` 중 하나 |
+| `dependsOn` | 선택 | task `id` 문자열의 배열. 생략하면 검증된 메모리 view에서 `[]`로 본다 |
+| `issue` | 선택 | 양의 정수인 GitHub Issue 번호 |
+| `risk` | 선택 | 비어 있지 않은 위험도 문자열 |
+
+실행 기록에 필요한 lifecycle 필드(`summary`, `error_message`, `blocked_reason`,
+`started_at`, `completed_at`, `failed_at`, `blocked_at`)도 선택적으로 보존할 수
+있다. v2 task에 v1 전용 `step` 또는 `name`, 정의되지 않은 임의 필드를 넣으면
+거부한다.
+
+예시는 [`phases/0-example-v2/index.json`](../phases/0-example-v2/index.json)에
+있다.
+
+## 정규화와 실행 경계
+
+`scripts/task_schema.py`의 validator가 반환하는 메모리 view는 두 형식을 공통으로
+다룬다.
+
+- v1 task는 기존 `step`/`name`을 그대로 사용한다.
+- v2 task는 배열 위치를 `step`, `id`를 `name`으로 임시 노출한다.
+- 이 alias는 현재 직렬 executor가 기존 companion `stepN.md`와 list-order를
+  사용할 수 있게 하는 메모리 값이며 v2 JSON에 저장하지 않는다.
+- `dependsOn`은 중복·self·존재하지 않는 task id를 거부하는 참조 검증만 한다.
+  ready set, cycle 처리, DAG 스케줄링, 병렬 실행은 후속 #22 범위다.
+
+읽기와 쓰기 사이에 형식을 바꾸지 않는다. 정규화 객체의 `to_payload()`는 원래
+`steps[]` 또는 `tasks[]` 컨테이너와 필드 생략을 보존하며, v1 입력에 synthetic v2
+필드를 추가하지 않는다.
+
+## 오류와 실행 전 검증
+
+다음 오류는 Codex subprocess 또는 GitHub 인증보다 먼저 발생해야 한다.
+
+- 중복 `id`
+- `dependsOn`의 누락된 task id
+- 자기 자신을 가리키는 dependency
+- 필수 필드 누락, 잘못된 타입, 공통 상태 밖의 `status`
+
+`TaskSchemaError`는 파일 경로와 필드 경로를 함께 출력한다. 예를 들어
+`phases/demo/index.json tasks[1].dependsOn[0]`처럼 문제 위치를 식별할 수 있어야
+하며, 여러 오류가 있으면 한 번에 모두 보고한다. `execute.py`와 `autopilot.py`는
+이 검증 실패를 성공이나 재시도로 바꾸지 않는다.
+
+## migration 규칙
+
+자동 migration은 하지 않는다. 기존 `index.json`, `stepN.md`, phase README를
+읽었다는 이유만으로 v1 파일을 v2로 덮어쓰거나, v2 alias를 파일에 기록해서는 안
+된다. v1을 v2로 바꾸려는 프로젝트는 별도의 명시적 opt-in 작업으로 다음을
+수행한다.
+
+1. 원본 phase와 index를 백업하고 변경 대상과 task id 매핑을 검토한다.
+2. dry-run에서 `id`, `objective`, `dependsOn`, `issue`, `risk`를 사람이 확정한다.
+3. 생성한 v2 index를 validator, companion step 문서, 전체 테스트로 확인한다.
+4. 사용자가 승인한 뒤에만 별도 commit으로 적용하고, 실패 시 원본을 복구한다.
+
+이번 schema 단계는 migration 명령이나 DAG scheduler를 추가하지 않는다. 원본을
+보존한 채 읽기 호환성과 검증만 제공한다.

--- a/docs/adr/0003-outcome-task-schema-v2.md
+++ b/docs/adr/0003-outcome-task-schema-v2.md
@@ -1,0 +1,38 @@
+# ADR-0003: Outcome task schema v2와 v1 호환
+
+## Status
+
+Accepted
+
+## Context
+
+기존 Harness는 phase index의 `steps[]`를 배열 순서대로 직렬 실행한다. 이후
+issue-driven outcome task에는 결과 목표, dependency reference, GitHub Issue와
+위험도 메타데이터가 필요하지만, 이미 존재하는 v1 phase와 실행 기록을 자동으로
+변환하거나 깨뜨릴 수는 없다.
+
+## Decision
+
+- v1 `steps[]`와 v2 `schemaVersion: 2` + `tasks[]`를 함께 지원한다.
+- v2 task의 필수 필드는 `id`, `objective`, `status`이고 `dependsOn`, `issue`,
+  `risk`는 선택 필드다. v1과 v2의 status 집합은
+  `pending`, `completed`, `error`, `blocked`로 공유한다.
+- `scripts/task_schema.py`를 두 실행 경로와 doctor가 공유한다. 중복 id,
+  self/unknown dependency, 필수 필드·타입·status 오류는 Codex 호출 전에
+  path/reason을 포함해 거부한다.
+- v2 입력은 메모리에서만 기존 serial executor가 이해하는 `step`/`name` alias를
+  제공한다. 저장 시 원래 컨테이너와 필드 형태를 보존한다.
+- `dependsOn`은 이번 결정에서 reference validation만 한다. ready set, cycle
+  처리, DAG scheduling과 parallelism은 후속 #22에서 별도 결정한다.
+- v1→v2 migration은 자동으로 하지 않는다. 변환은 backup, dry-run, validator,
+  사용자 승인과 별도 commit을 포함한 명시적 opt-in 작업이어야 한다.
+
+## Consequences
+
+- 기존 v1 phase는 `phases/0-example/index.json`과 같은 형태로 계속 실행된다.
+- 새 v2 phase는 outcome metadata를 기록하면서도 현재 `stepN.md`와 직렬 실행을
+  재사용할 수 있다.
+- v2 dependency graph의 실행 가능 집합이나 cycle은 아직 계산하지 않으므로,
+  이를 요구하는 구현은 #22 범위까지 기다려야 한다.
+- schema 변경 시 `docs/TASK_SCHEMA.md`, 예제, doctor와 두 실행 경로의 테스트를
+  함께 갱신해야 한다.

--- a/guides/CONFIGURATION.md
+++ b/guides/CONFIGURATION.md
@@ -54,6 +54,19 @@ profile override가 없으면 `docs/COMMANDS.md`, 그 다음 프로젝트 manife
 - Python: `pyproject.toml`, `uv.lock`, `pytest`, `ruff`
 - Node: `package.json`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`
 
+## Phase task index
+
+`phases/{phase}/index.json`의 v1 `steps[]`와 v2 `tasks[]` 필드, 공통 status,
+dependency reference와 migration 경계는 [docs/TASK_SCHEMA.md](../docs/TASK_SCHEMA.md)를
+기준으로 합니다. `execute.py`와 `autopilot.py`는 phase index를 먼저 검증하므로
+중복 id, missing/self dependency, 잘못된 타입이나 status는 Codex 호출 전에
+파일·필드 경로와 reason을 출력하고 중단합니다.
+
+v2의 `dependsOn`은 현재 배열 순서의 직렬 실행을 바꾸지 않는 메타데이터입니다.
+ready set, cycle 처리, DAG 스케줄링과 병렬 실행은 후속 범위이며, v1 phase를 v2로
+자동 migration하지 않습니다. 변환이 필요하면 원본 백업과 dry-run, 사용자 승인,
+별도 commit을 갖춘 명시적 opt-in 작업으로 수행합니다.
+
 ## Progressive guardrails
 
 `scripts/execute.py`는 Codex prompt에 AGENTS, phase 문서, 관련 문서의 본문을

--- a/guides/PROMPTS.md
+++ b/guides/PROMPTS.md
@@ -8,6 +8,10 @@
 phase 설계가 끝나고 설계 문서가 commit된 뒤에는 일반 작업 모드에서
 "운영: autopilot으로 구현 시작" 프롬프트를 사용합니다.
 
+phase index는 기존 v1 `steps[]` 또는 outcome 중심 v2 `tasks[]` 중 하나를 선택합니다.
+필드와 migration 경계는 [docs/TASK_SCHEMA.md](../docs/TASK_SCHEMA.md)를 먼저
+확인하고, 기존 phase를 v2로 자동 변환하지 않습니다.
+
 ## 셋업: 한 번에 정리하기
 
 프로젝트 그림이 어느 정도 잡혀 있으면 아래 통합 프롬프트 하나로 시작합니다.
@@ -88,6 +92,10 @@ phase/step 설계안을 만들 때 사용합니다.
 Harness skill을 사용해서 확정된 문서를 기준으로 phase를 설계해줘.
 MVP를 phases/{phase}/README.md, index.json, stepN.md로 나누되, 각 step은
 하나의 레이어 또는 모듈만 다루게 작게 쪼개줘.
+기존 phase는 v1 `steps[]`를 그대로 유지하고, 새 outcome task가 필요할 때만
+`docs/TASK_SCHEMA.md`의 v2 `tasks[]`를 사용해줘. v2의 `dependsOn`은 현재
+직렬 list-order를 바꾸는 scheduler가 아니라 검증할 reference metadata로만
+기록해줘.
 각 step에는 읽어야 할 파일, 작업, 인수 기준, 검증 절차, 금지사항을 포함하고,
 docs/COMMANDS.md의 test/build 명령을 완료 기준에 반영해줘.
 아직 phase를 실행하거나 코드를 구현하지 말고, 먼저 phase/step 설계안을 제시해줘.

--- a/guides/UPGRADE.md
+++ b/guides/UPGRADE.md
@@ -36,6 +36,11 @@
 않습니다. 이름이 충돌하면 업그레이드 전에 프로젝트 스킬 이름을 바꾸거나 공통
 스킬 편입 여부를 결정합니다.
 
+`docs/TASK_SCHEMA.md`는 phase index 계약을 설명하는 기준 문서지만 `docs/` 아래
+프로젝트 소유 파일로 취급합니다. `scripts/upgrade.py`는 이를 포함한 프로젝트의
+`docs/`, `phases/`, `issues/`, `archive/`를 자동 덮어쓰지 않습니다. 기존 인스턴스는
+계약을 확인한 뒤 필요한 문서 변경을 수동으로 검토합니다.
+
 `.github/workflows/template-ci.yml`은 템플릿 repo 전용 검증입니다. 실제 프로젝트
 인스턴스에는 복사하지 않고, 이미 복사했다면 삭제합니다. 실제 프로젝트의 CI는
 `docs/COMMANDS.md`에 확정한 `lint`, `test`, `build` 명령 기준으로 별도 작성합니다.
@@ -71,6 +76,23 @@
 
 수동으로 복사하려면 위 "파일 소유 구분" 표를 그대로 따르고, 마지막에
 `templateVersion`을 직접 갱신합니다.
+
+## phase index migration
+
+Harness 업그레이드는 phase index를 자동으로 v1에서 v2로 변환하지 않습니다.
+`phases/{phase}/index.json`, `stepN.md`, README와 실행 기록은 프로젝트 소유이며,
+템플릿의 `scripts/task_schema.py`는 두 형식을 읽고 검증만 합니다. v2로 전환하려는
+프로젝트는 별도 opt-in 작업에서 다음 순서를 지킵니다.
+
+1. 원본 phase/index를 백업하고 v1 task와 새 v2 `id`의 매핑을 확정합니다.
+2. `objective`, `dependsOn`, `issue`, `risk`를 dry-run으로 검토하고 누락된
+   dependency와 companion 문서를 확인합니다.
+3. validator, 전체 테스트와 phase 문서 검증을 통과시킨 뒤 사용자 승인을 받습니다.
+4. 승인된 변경만 별도 commit으로 적용하고, 실패하면 백업한 v1 원본으로 복구합니다.
+
+읽기 중 생성되는 v2의 `step`/`name` alias는 메모리 값이며 JSON에 저장되지
+않습니다. `dependsOn`은 현재 직렬 실행 순서를 바꾸지 않고, DAG scheduler·cycle
+처리·parallelism은 후속 기능으로 남겨 둡니다.
 
 ## 템플릿 repo에서 버전 올리기
 

--- a/phases/0-example-v2/README.md
+++ b/phases/0-example-v2/README.md
@@ -1,0 +1,35 @@
+# Phase: 0-example-v2
+
+## 목표
+
+- v2 outcome task와 v1 실행기의 호환 형태를 보여준다.
+
+## 작업 범위
+
+- `index.json`의 `tasks[]`에 결과 목표, 의존성, Issue와 위험도 메타데이터를
+  기록한다.
+- 현재 Harness는 배열 순서를 그대로 따라 한 번에 하나의 task를 실행한다.
+
+## 제외 범위
+
+- `dependsOn`을 이용한 DAG 스케줄링, ready set 계산, 병렬 실행은 이 예시에
+  포함하지 않는다.
+- 기존 phase 파일을 v2로 자동 변환하지 않는다.
+
+## Steps
+
+| 순서 | Task id | 결과 목표 | 상태 |
+| ---: | --- | --- | --- |
+| 0 | project-setup | 프로젝트 골격을 준비한다 | pending |
+| 1 | outcome-check | 예시 결과를 확인한다 | pending |
+
+## 완료 기준
+
+- 두 task가 선언된 배열 순서대로 실행된다.
+- v2 필수 필드와 dependency reference가 schema validator를 통과한다.
+
+## 검증 명령
+
+```powershell
+python scripts/checks.py --stage manual
+```

--- a/phases/0-example-v2/docs-checks.json
+++ b/phases/0-example-v2/docs-checks.json
@@ -1,0 +1,38 @@
+{
+  "paths": [
+    "phases/0-example-v2"
+  ],
+  "skipDirs": [
+    ".git",
+    "__pycache__"
+  ],
+  "skipSuffixes": [
+    ".json"
+  ],
+  "required": [
+    {
+      "name": "v2 task format marker",
+      "paths": ["phases/0-example-v2/index.json"],
+      "pattern": "schemaVersion.*2"
+    },
+    {
+      "name": "outcome objective",
+      "paths": ["phases/0-example-v2/index.json"],
+      "pattern": "objective"
+    }
+  ],
+  "finalRequired": [
+    {
+      "name": "example completion contract",
+      "paths": ["phases/0-example-v2/README.md"],
+      "pattern": "## 완료 기준"
+    }
+  ],
+  "forbidden": [
+    {
+      "name": "parallel scheduler example",
+      "paths": ["phases/0-example-v2/README.md"],
+      "pattern": "무제한 병렬 실행"
+    }
+  ]
+}

--- a/phases/0-example-v2/index.json
+++ b/phases/0-example-v2/index.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 2,
+  "project": "<프로젝트명>",
+  "phase": "0-example-v2",
+  "tasks": [
+    {
+      "id": "project-setup",
+      "objective": "프로젝트 골격을 준비한다.",
+      "dependsOn": [],
+      "issue": 16,
+      "risk": "low",
+      "status": "pending"
+    },
+    {
+      "id": "outcome-check",
+      "objective": "예시 결과를 확인한다.",
+      "dependsOn": ["project-setup"],
+      "risk": "low",
+      "status": "pending"
+    }
+  ]
+}

--- a/phases/0-example-v2/scope-rules.json
+++ b/phases/0-example-v2/scope-rules.json
@@ -1,0 +1,14 @@
+{
+  "extraForbidden": [
+    {
+      "message": "예시 범위 밖 스케줄러",
+      "anyLowered": ["parallel scheduler"]
+    }
+  ],
+  "allowedScopeMessages": [
+    {
+      "message": "예시 범위 밖 스케줄러",
+      "steps": [0, 1]
+    }
+  ]
+}

--- a/phases/0-example-v2/step0.md
+++ b/phases/0-example-v2/step0.md
@@ -1,0 +1,21 @@
+# 단계 0: project-setup
+
+## 읽어야 할 파일
+
+- `/docs/TASK_SCHEMA.md`
+- `/phases/0-example-v2/README.md`
+
+## 작업
+
+예시 프로젝트 골격을 준비한다.
+
+## 인수 기준
+
+```powershell
+python scripts/checks.py --stage manual
+```
+
+## 금지사항
+
+- `dependsOn`을 스케줄러로 해석하거나 병렬 실행을 추가하지 마라. 이유: 이
+  예시는 현재의 직렬 실행 계약만 보여준다.

--- a/phases/0-example-v2/step1.md
+++ b/phases/0-example-v2/step1.md
@@ -1,0 +1,21 @@
+# 단계 1: outcome-check
+
+## 읽어야 할 파일
+
+- `/docs/TASK_SCHEMA.md`
+- `/phases/0-example-v2/index.json`
+
+## 작업
+
+앞 task가 남긴 예시 결과를 확인한다.
+
+## 인수 기준
+
+```powershell
+python scripts/checks.py --stage manual
+```
+
+## 금지사항
+
+- 기존 v1 phase index를 자동으로 다시 쓰지 마라. 이유: migration은 명시적
+  opt-in 작업으로만 허용된다.

--- a/phases/README.md
+++ b/phases/README.md
@@ -2,9 +2,11 @@
 
 Harness phase 파일은 프로젝트별 MVP 작업을 작은 step으로 나눠 실행하기 위한 템플릿입니다.
 
-형식이 채워진 참고용 예시는 `0-example/`에 있습니다. 실행 대상이 아니라 형식
-레퍼런스이며, `python scripts/doctor.py --template`이 예시의 스키마를 검증합니다.
-실제 phase를 만들 때 예시를 복사해 시작해도 됩니다.
+형식이 채워진 참고용 예시는 `0-example/`(v1)와 `0-example-v2/`(outcome v2)에
+있습니다. 실행 대상이 아니라 형식 레퍼런스이며, `python scripts/doctor.py
+--template`이 두 예시의 schema와 companion 문서를 검증합니다. 전체 계약은
+[`docs/TASK_SCHEMA.md`](../docs/TASK_SCHEMA.md)에 있습니다. 실제 phase를 만들 때
+적절한 예시를 복사해 시작해도 됩니다.
 
 새 phase는 아래 구조로 만듭니다.
 
@@ -23,9 +25,12 @@ phases/{phase-name}/
 우선 계약으로 삼고, 미래 step에 배정된 기능이 아직 없다는 이유만으로 blocker 처리하지
 않습니다.
 
-`index.json`에는 step 목록과 상태를 기록합니다. `scripts/execute.py`와
-`scripts/autopilot.py`가 `pending`, `completed`, `error`, `blocked` 상태와
-타임스탬프를 갱신합니다.
+`index.json`에는 v1 `steps[]` 또는 v2 `tasks[]` 목록과 상태를 기록합니다.
+`scripts/task_schema.py`가 두 형식을 구분하고 path/reason validation을 먼저
+수행하며, `scripts/execute.py`와 `scripts/autopilot.py`가
+`pending`, `completed`, `error`, `blocked` 상태와 timestamp를 갱신합니다. v2의
+`dependsOn`은 현재 list-order 직렬 실행을 바꾸지 않으며, 기존 index를 자동
+migration하지 않습니다.
 
 `docs-checks.json`에는 phase 최종 완료 전에 자동으로 확인할 문서 정합성 규칙을
 적습니다. `manual` stage에서는 실행하지 않고, 모든 pending step이 끝난 뒤

--- a/phases/harness-v2-modernization/COMPATIBILITY.md
+++ b/phases/harness-v2-modernization/COMPATIBILITY.md
@@ -17,6 +17,27 @@
 - v2 reader가 기록한 상태를 v1 fallback이 읽지 못할 가능성이 있으면 원본을
   보존하고 변환 전 backup·검증·복구 절차를 제공한다.
 
+## task schema v2 (#16)
+
+- v1은 기존 `steps[]`와 `step`, `name`, `status`를 그대로 읽는다. 현재 fixture인
+  `phases/0-example/index.json`은 v1 보존 검증의 기준이며 v2 필드를 자동으로
+  추가하지 않는다.
+- v2는 `schemaVersion: 2`, `tasks[]`와 각 task의 필수 `id`, `objective`, `status`,
+  선택 `dependsOn`, `issue`, `risk`를 사용한다. 공통 status는 v1과 동일하게
+  `pending`, `completed`, `error`, `blocked`다.
+- `scripts/task_schema.py`가 두 형식을 구분·검증한다. 중복 id, self/unknown
+  dependency, 필수 필드·타입·status 오류는 파일 및 필드 경로와 reason을 포함해
+  Codex와 GitHub 인증 전에 거부한다.
+- v2 task의 배열 위치와 id에서 파생한 `step`/`name`은 현재 serial executor를
+  위한 메모리 alias일 뿐이다. 저장할 때는 원래 `tasks[]` 형식과 필드 생략을
+  보존한다.
+- `dependsOn`은 이 단계에서 reference validation만 수행한다. ready set, cycle
+  처리, DAG scheduling과 parallelism은 #22의 범위이며 #16에서 선행 구현하지
+  않는다.
+- v1→v2 변환은 자동으로 실행하지 않는다. 변환이 필요한 프로젝트는 원본 백업,
+  dry-run 매핑 검토, validator와 companion 문서 검증, 사용자 승인, 별도 commit을
+  포함한 명시적 opt-in 절차를 사용한다.
+
 ## fallback 원칙
 
 - SDK 또는 native review가 설치되지 않았거나 capability 검증, 인증, sandbox,

--- a/phases/harness-v2-modernization/README.md
+++ b/phases/harness-v2-modernization/README.md
@@ -50,7 +50,10 @@
 
 세부 목표와 금지사항은 각각의 `stepN.md`를 따른다. 기준선은
 [`BASELINE.md`](BASELINE.md), eval 표본과 계산식은 [`EVALS.md`](EVALS.md), v1
-보존 및 rollback 규칙은 [`COMPATIBILITY.md`](COMPATIBILITY.md)에 고정한다.
+보존 및 rollback 규칙은 [`COMPATIBILITY.md`](COMPATIBILITY.md)에 고정한다. v1/v2
+phase index 필드와 migration 경계는 루트 [`docs/TASK_SCHEMA.md`](../../docs/TASK_SCHEMA.md)에
+고정한다. #16에서는 v2 dependency를 검증하고 표현만 하며, DAG 실행은 #22에서
+다룬다.
 
 ## Step PR 리뷰 원칙
 

--- a/phases/harness-v2-modernization/docs-checks.json
+++ b/phases/harness-v2-modernization/docs-checks.json
@@ -34,6 +34,21 @@
       "name": "issue sequence through release gate",
       "paths": ["phases/harness-v2-modernization/README.md"],
       "pattern": "실행 순서 ID: #13 -> #14 -> #15 -> #16 -> #17 -> #18 -> #19 -> #20 -> #21 -> #22 -> #23"
+    },
+    {
+      "name": "task schema v2 contract",
+      "paths": ["docs/TASK_SCHEMA.md"],
+      "pattern": "schemaVersion: 2"
+    },
+    {
+      "name": "task dependency validation boundary",
+      "paths": ["docs/TASK_SCHEMA.md"],
+      "pattern": "중복·self·존재하지 않는 task id"
+    },
+    {
+      "name": "task migration opt-in boundary",
+      "paths": ["docs/TASK_SCHEMA.md"],
+      "pattern": "자동 migration은 하지 않는다"
     }
   ],
   "finalRequired": [],

--- a/phases/harness-v2-modernization/index.json
+++ b/phases/harness-v2-modernization/index.json
@@ -23,7 +23,13 @@
       "completed_at": "2026-09-04T09:42:36Z",
       "summary": "guardrail prompt를 경로·step 계약 중심으로 축소하고 참조 누락을 Codex 호출 전에 진단했으며 v1 대비 prompt 계약 proxy를 기록했다."
     },
-    { "step": 3, "name": "task-schema-v2", "status": "pending" },
+    {
+      "step": 3,
+      "name": "task-schema-v2",
+      "status": "completed",
+      "completed_at": "2026-09-04T19:47:12+0900",
+      "summary": "outcome task v2 schema와 shared validation을 추가하고 v1 steps 실행·저장 형식과 serial list-order를 보존했다."
+    },
     { "step": 4, "name": "isolated-worktree", "status": "pending" },
     { "step": 5, "name": "sdk-spike", "status": "pending" },
     { "step": 6, "name": "runner-adapter", "status": "pending" },

--- a/phases/harness-v2-modernization/step3.md
+++ b/phases/harness-v2-modernization/step3.md
@@ -5,21 +5,26 @@
 - `/phases/harness-v2-modernization/README.md`
 - `/phases/harness-v2-modernization/COMPATIBILITY.md`
 - `/phases/0-example/index.json`
+- `/phases/0-example-v2/index.json`
+- `/docs/TASK_SCHEMA.md`
 - `/.agents/skills/harness/SKILL.md`
 - `/.agents/skills/review/SKILL.md`
 - `/scripts/execute.py`
 - `/scripts/autopilot.py`
 - `/scripts/doctor.py`
+- `/scripts/task_schema.py`
 - `/scripts/tests/`
 
 ## 작업
 
-- outcome task의 `id`, `objective`, `dependsOn`, `issue`, `risk` 필드와 validation
-  오류를 정의한다.
+- outcome task의 `id`, `objective`, `dependsOn`, `issue`, `risk` 필드와 공통 status,
+  path/reason validation 오류를 정의한다.
 - 기존 `step`, `name`, `status`만 가진 v1 파일을 migration 없이 계속 읽고 같은
   의미로 실행한다.
-- 예제, Harness와 review skill, doctor, unit test, opt-in migration 규칙을 함께
-  갱신한다.
+- execute/autopilot이 GitHub 또는 Codex 호출 전에 validator를 사용하도록 하고,
+  v2 task는 list order의 직렬 실행과 기존 `stepN.md` 계약을 유지한다.
+- 예제, Harness와 review skill, doctor, unit test, 문서와 opt-in migration 규칙을
+  함께 갱신한다.
 
 ## 인수 기준
 
@@ -32,8 +37,8 @@ git diff --check
 ## 검증 절차
 
 1. v1 fixture와 v2 valid/invalid fixture를 먼저 고정한다.
-2. 중복 id, missing/self/unknown dependency와 잘못된 status가 Codex 호출 전에
-   거부되는지 확인한다.
+2. 중복 id, missing/self/unknown dependency, 필수 필드·잘못된 타입·잘못된 status가
+   GitHub 인증과 Codex 호출 전에 path/reason과 함께 거부되는지 확인한다.
 3. EVAL-V1을 실행하고 원본 phase/index가 자동 변경되지 않았는지 대조한다.
 4. 성공하면 index의 해당 step을 `completed`와 한 줄 `summary`로 갱신한다.
 
@@ -42,4 +47,6 @@ git diff --check
 - DAG scheduler나 병렬 실행을 구현하지 마라. 이유: Step 9 범위다.
 - 기존 phase 파일을 자동 덮어쓰지 마라. 이유: v1 보존 계약을 위반한다.
 - 새 필드가 없다는 이유로 v1 입력을 실패시키지 마라. 이유: additive schema다.
+- v1 index나 v2 index를 자동 migration하지 마라. 이유: source phase와 사용자
+  승인 없는 파일 덮어쓰기를 방지해야 한다.
 - 기존 테스트를 깨뜨리지 마라.

--- a/scripts/autopilot.py
+++ b/scripts/autopilot.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import guard
+import task_schema
 from codex_common import (
     ALLOWED_CODEX_EFFORTS,
     CODEX_ENV_CONFIG,
@@ -406,6 +407,10 @@ class AutopilotRunner:
                 + status
             )
 
+        # Validate the whole phase index before authentication, branch sync or
+        # any step can reach execute.py/Codex. This is intentionally a shape
+        # and reference check only; task selection remains list-order serial.
+        self._load_phase_index()
         self._gh("auth", "status")
         self._git("remote", "get-url", "origin")
         self._sync_base()
@@ -431,8 +436,12 @@ class AutopilotRunner:
     def _phase_index_path(self) -> Path:
         return self.root / "phases" / self.phase / "index.json"
 
-    def _load_phase_index(self) -> dict:
-        return json.loads(self._phase_index_path().read_text(encoding="utf-8"))
+    def _load_phase_index(self) -> task_schema.NormalizedPhaseIndex:
+        path = self._phase_index_path()
+        try:
+            return task_schema.load_phase_index(path, display_path=path.relative_to(self.root))
+        except task_schema.TaskSchemaError as exc:
+            raise AutopilotError(str(exc)) from exc
 
     def _next_pending_step(self) -> dict | None:
         index = self._load_phase_index()
@@ -527,6 +536,8 @@ class AutopilotRunner:
         return next((s for s in index.get("steps", []) if s.get("step") == step_num), None)
 
     def _step_task_summary(self, step: dict) -> str:
+        if step.get("objective"):
+            return str(step["objective"])
         path = self.root / "phases" / self.phase / f"step{step['step']}.md"
         if not path.exists():
             return step["name"]
@@ -939,13 +950,19 @@ class AutopilotRunner:
     def _codex_review_prompt(self, step: dict) -> str:
         step_num = step.get("step", "?")
         step_name = step.get("name", "unknown")
+        task_metadata = ""
+        if step.get("id"):
+            task_metadata = (
+                f" Task id is `{step['id']}`; treat `dependsOn`, `issue`, and `risk` as metadata only."
+                " Do not change serial/list-order execution in this step."
+            )
         phase_readme = f"phases/{self.phase}/README.md"
         step_file = f"phases/{self.phase}/step{step_num}.md"
         python_bin = str(Path(sys.executable))
         return (
             "Read-only review only. Do not modify files. "
             f"Review the current branch diff against origin/{self.base} for Harness project rules. "
-            f"Current Harness step is Step {step_num} `{step_name}`. "
+            f"Current Harness step is Step {step_num} `{step_name}`.{task_metadata} "
             "Ignore generated review-failure records under issues/**; they are audit logs, not implementation changes. "
             f"Check {phase_readme} and {step_file} first, then AGENTS.md, docs/PRD.md, "
             "docs/ARCHITECTURE.md, docs/ADR.md, docs/adr/, and docs/COMMANDS.md. "

--- a/scripts/codex_common.py
+++ b/scripts/codex_common.py
@@ -14,7 +14,7 @@ from pathlib import Path
 # .codex/project-profile.json `templateVersion`에 기록하고, doctor가 둘을
 # 비교해 "harness 파일과 동기화 기록이 어긋난 상태"를 잡는다.
 # 업그레이드 절차는 템플릿 guides/UPGRADE.md를 따른다.
-TEMPLATE_VERSION = "2026.09.04"
+TEMPLATE_VERSION = "2026.09.04.1"
 
 ALLOWED_CODEX_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
 CODEX_EXEC_TIMEOUT = 1800

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import checks
 import codex_common
+import task_schema
 
 ROOT = Path(__file__).resolve().parent.parent
 REQUIRED_FILES = [
@@ -41,7 +42,9 @@ REQUIRED_FILES = [
     "scripts/codex_common.py",
     "scripts/doctor.py",
     "scripts/guard.py",
+    "scripts/task_schema.py",
     "scripts/upgrade.py",
+    "docs/TASK_SCHEMA.md",
 ]
 TEMPLATE_REQUIRED_FILES = [
     ".github/workflows/template-ci.yml",
@@ -58,13 +61,14 @@ PYTHON_ONLY_HOOK_MARKER = "python .codex/hooks/tdd-guard.py"
 # phase 파일 형식의 살아있는 예시. SKILL.md 산문과 달리 스키마가 깨지면
 # template 모드 doctor(및 CI)가 잡아내므로, 형식 변경 시 예시도 함께 갱신된다.
 EXAMPLE_PHASE_DIR = "phases/0-example"
+V2_EXAMPLE_PHASE_DIR = "phases/0-example-v2"
 EXAMPLE_PHASE_FILES = (
     "README.md",
     "index.json",
     "docs-checks.json",
     "scope-rules.json",
 )
-VALID_STEP_STATUSES = {"pending", "completed", "error", "blocked"}
+VALID_STEP_STATUSES = task_schema.VALID_STATUSES
 
 
 def _status(ok: bool) -> str:
@@ -195,45 +199,89 @@ def _template_contract_issues(root: Path) -> list[str]:
             elif "forbidden" in payload and not isinstance(payload["forbidden"], list):
                 issues.append(".codex/scope-rules.json `forbidden` must be a list.")
 
-    issues.extend(_example_phase_issues(root))
+    issues.extend(
+        _phase_index_schema_issues(
+            root,
+            excluded={EXAMPLE_PHASE_DIR, V2_EXAMPLE_PHASE_DIR},
+        )
+    )
+    issues.extend(_example_phase_issues(root, EXAMPLE_PHASE_DIR))
+    issues.extend(_example_phase_issues(root, V2_EXAMPLE_PHASE_DIR))
     return issues
 
 
-def _example_phase_issues(root: Path) -> list[str]:
-    phase_dir = root / EXAMPLE_PHASE_DIR
+def _phase_index_schema_issues(root: Path, excluded: set[str] | None = None) -> list[str]:
+    """Validate every phase-local index without changing its source format."""
+    phases_dir = root / "phases"
+    if not phases_dir.is_dir():
+        return []
+
+    excluded = excluded or set()
+    issues: list[str] = []
+    for path in sorted(phases_dir.glob("*/index.json")):
+        rel = path.relative_to(root).as_posix()
+        if rel.rsplit("/", 1)[0] in excluded:
+            continue
+        try:
+            task_schema.load_phase_index(path, display_path=rel)
+        except task_schema.TaskSchemaError as exc:
+            issues.extend(str(error) for error in exc.errors)
+    return issues
+
+
+def _example_phase_issues(root: Path, phase_rel: str) -> list[str]:
+    phase_dir = root / phase_rel
     if not phase_dir.is_dir():
-        return [f"{EXAMPLE_PHASE_DIR}/ example phase is missing."]
+        return [f"{phase_rel}/ example phase is missing."]
 
     issues: list[str] = []
     for rel in EXAMPLE_PHASE_FILES:
         if not (phase_dir / rel).exists():
-            issues.append(f"{EXAMPLE_PHASE_DIR}/{rel} is missing.")
+            issues.append(f"{phase_rel}/{rel} is missing.")
 
-    issues.extend(_example_phase_index_issues(phase_dir))
-    issues.extend(_example_docs_checks_issues(root, phase_dir))
-    issues.extend(_example_scope_rules_issues(phase_dir))
+    issues.extend(_example_phase_index_issues(phase_dir, phase_rel))
+    issues.extend(_example_docs_checks_issues(root, phase_dir, phase_rel))
+    issues.extend(_example_scope_rules_issues(phase_dir, phase_rel))
     return issues
 
 
-def _example_phase_index_issues(phase_dir: Path) -> list[str]:
+def _example_phase_index_issues(phase_dir: Path, phase_rel: str) -> list[str]:
     path = phase_dir / "index.json"
     if not path.exists():
         return []
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        return [f"{EXAMPLE_PHASE_DIR}/index.json is not valid JSON: {exc}"]
+        return [f"{phase_rel}/index.json is not valid JSON: {exc}"]
     if not isinstance(payload, dict):
-        return [f"{EXAMPLE_PHASE_DIR}/index.json must contain a JSON object."]
+        return [f"{phase_rel}/index.json must contain a JSON object."]
 
     issues: list[str] = []
     if payload.get("phase") != phase_dir.name:
-        issues.append(f"{EXAMPLE_PHASE_DIR}/index.json `phase` must match the directory name.")
+        issues.append(f"{phase_rel}/index.json `phase` must match the directory name.")
 
     steps = payload.get("steps")
-    if not isinstance(steps, list) or not steps:
-        issues.append(f"{EXAMPLE_PHASE_DIR}/index.json `steps` must be a non-empty list.")
+    task_key = "steps" if "steps" in payload else "tasks"
+    if not isinstance(steps, list) and task_key == "steps":
+        issues.extend(_phase_index_schema_issues_for_path(path, phase_rel))
         return issues
+    if task_key == "tasks":
+        tasks = payload.get("tasks")
+        if not isinstance(tasks, list):
+            issues.extend(_phase_index_schema_issues_for_path(path, phase_rel))
+            return issues
+        issues.extend(_phase_index_schema_issues_for_path(path, phase_rel))
+        for index, entry in enumerate(tasks):
+            if isinstance(entry, dict):
+                issues.extend(_example_step_file_issues(phase_dir, index, phase_rel))
+        return issues
+    if not steps:
+        issues.extend(_phase_index_schema_issues_for_path(path, phase_rel))
+        return issues
+
+    # The shared schema module owns status/type validation. This loop retains
+    # the example-only companion step-file check and its stable diagnostics.
+    issues.extend(_phase_index_schema_issues_for_path(path, phase_rel))
 
     for entry in steps:
         if (
@@ -242,37 +290,39 @@ def _example_phase_index_issues(phase_dir: Path) -> list[str]:
             or not isinstance(entry.get("name"), str)
         ):
             issues.append(
-                f"{EXAMPLE_PHASE_DIR}/index.json steps need an integer `step` and a string `name`."
+                f"{phase_rel}/index.json steps need an integer `step` and a string `name`."
             )
             continue
-        if entry.get("status") not in VALID_STEP_STATUSES:
-            issues.append(
-                f"{EXAMPLE_PHASE_DIR}/index.json step {entry['step']} status must be one of "
-                + ", ".join(sorted(VALID_STEP_STATUSES))
-                + "."
-            )
-        issues.extend(_example_step_file_issues(phase_dir, entry["step"]))
+        issues.extend(_example_step_file_issues(phase_dir, entry["step"], phase_rel))
     return issues
 
 
-def _example_step_file_issues(phase_dir: Path, step_num: int) -> list[str]:
+def _phase_index_schema_issues_for_path(path: Path, phase_rel: str) -> list[str]:
+    try:
+        task_schema.load_phase_index(path, display_path=f"{phase_rel}/index.json")
+    except task_schema.TaskSchemaError as exc:
+        return [str(error) for error in exc.errors]
+    return []
+
+
+def _example_step_file_issues(phase_dir: Path, step_num: int, phase_rel: str) -> list[str]:
     step_path = phase_dir / f"step{step_num}.md"
     if not step_path.exists():
-        return [f"{EXAMPLE_PHASE_DIR}/step{step_num}.md is missing."]
+        return [f"{phase_rel}/step{step_num}.md is missing."]
 
     issues: list[str] = []
     text = step_path.read_text(encoding="utf-8")
     for section in ("## 작업", "## 인수 기준", "## 금지사항"):
         if section not in text:
-            issues.append(f"{EXAMPLE_PHASE_DIR}/step{step_num}.md must contain a `{section}` section.")
+            issues.append(f"{phase_rel}/step{step_num}.md must contain a `{section}` section.")
     if not codex_common.read_acceptance_commands(step_path):
         issues.append(
-            f"{EXAMPLE_PHASE_DIR}/step{step_num}.md `## 인수 기준` must contain fenced shell commands."
+            f"{phase_rel}/step{step_num}.md `## 인수 기준` must contain fenced shell commands."
         )
     return issues
 
 
-def _example_docs_checks_issues(root: Path, phase_dir: Path) -> list[str]:
+def _example_docs_checks_issues(root: Path, phase_dir: Path, phase_rel: str) -> list[str]:
     path = phase_dir / "docs-checks.json"
     if not path.exists():
         return []
@@ -283,7 +333,7 @@ def _example_docs_checks_issues(root: Path, phase_dir: Path) -> list[str]:
 
     issues: list[str] = []
     if not config.paths:
-        issues.append(f"{EXAMPLE_PHASE_DIR}/docs-checks.json must define top-level `paths`.")
+        issues.append(f"{phase_rel}/docs-checks.json must define top-level `paths`.")
     for key, rules in (
         ("required", config.required),
         ("finalRequired", config.final_required),
@@ -291,34 +341,34 @@ def _example_docs_checks_issues(root: Path, phase_dir: Path) -> list[str]:
     ):
         if not rules:
             issues.append(
-                f"{EXAMPLE_PHASE_DIR}/docs-checks.json must demonstrate at least one `{key}` rule."
+                f"{phase_rel}/docs-checks.json must demonstrate at least one `{key}` rule."
             )
     return issues
 
 
-def _example_scope_rules_issues(phase_dir: Path) -> list[str]:
+def _example_scope_rules_issues(phase_dir: Path, phase_rel: str) -> list[str]:
     path = phase_dir / "scope-rules.json"
     if not path.exists():
         return []
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        return [f"{EXAMPLE_PHASE_DIR}/scope-rules.json is not valid JSON: {exc}"]
+        return [f"{phase_rel}/scope-rules.json is not valid JSON: {exc}"]
     if not isinstance(payload, dict):
-        return [f"{EXAMPLE_PHASE_DIR}/scope-rules.json must contain a JSON object."]
+        return [f"{phase_rel}/scope-rules.json must contain a JSON object."]
 
     issues: list[str] = []
     for key in ("extraForbidden", "allowedScopeMessages"):
         rules = payload.get(key)
         if not isinstance(rules, list) or not rules:
             issues.append(
-                f"{EXAMPLE_PHASE_DIR}/scope-rules.json must demonstrate at least one `{key}` rule."
+                f"{phase_rel}/scope-rules.json must demonstrate at least one `{key}` rule."
             )
             continue
         for rule in rules:
             if not isinstance(rule, dict) or not isinstance(rule.get("message"), str) or not rule["message"]:
                 issues.append(
-                    f"{EXAMPLE_PHASE_DIR}/scope-rules.json `{key}` rules need a non-empty `message`."
+                    f"{phase_rel}/scope-rules.json `{key}` rules need a non-empty `message`."
                 )
                 break
     return issues
@@ -345,6 +395,7 @@ def collect_issues(root: Path = ROOT, mode: str = "instance") -> list[str]:
         issues.extend(_template_contract_issues(root))
 
     if mode == "instance":
+        issues.extend(_phase_index_schema_issues(root))
         selected = checks.collect_checks(root, "manual")
         missing = checks.missing_required_checks(selected)
         if missing:

--- a/scripts/execute.py
+++ b/scripts/execute.py
@@ -23,6 +23,7 @@ from typing import Optional
 
 import checks
 import guard
+import task_schema
 from codex_common import (
     ALLOWED_CODEX_EFFORTS,
     CODEX_EXEC_TIMEOUT,
@@ -115,10 +116,11 @@ class StepExecutor:
             print(f"ERROR: {self._index_file} not found")
             sys.exit(1)
 
-        idx = self._read_json(self._index_file)
+        idx = self._read_phase_index()
         self._project = idx.get("project", "project")
         self._phase_name = idx.get("phase", phase_dir_name)
         self._total = len(idx["steps"])
+        self._schema_version = idx.schema_version
         if self._branch_name is None:
             self._branch_name = f"codex/{self._phase_name}"
 
@@ -162,7 +164,15 @@ class StepExecutor:
 
     @staticmethod
     def _write_json(p: Path, data: dict):
+        if isinstance(data, task_schema.NormalizedPhaseIndex):
+            data = data.to_payload()
         p.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    def _read_phase_index(self) -> task_schema.NormalizedPhaseIndex:
+        return task_schema.load_phase_index(
+            self._index_file,
+            display_path=f"phases/{self._phase_dir_name}/index.json",
+        )
 
     # --- git ---
 
@@ -409,7 +419,7 @@ class StepExecutor:
     def _build_step_context(index: dict) -> str:
         lines = [
             f"- Step {s['step']} ({s['name']}): {s['summary']}"
-            for s in index["steps"]
+            for s in task_schema.tasks_from_index(index)
             if s["status"] == "completed" and s.get("summary")
         ]
         if not lines:
@@ -482,6 +492,8 @@ class StepExecutor:
             )
 
         objective = self._section_text(markdown, "## 작업")
+        if step.get("objective"):
+            objective = str(step["objective"])
         acceptance = self._section_text(markdown, "## 인수 기준")
         constraints = self._section_text(markdown, "## 금지사항")
         return step_path, normalized_paths, objective, acceptance, constraints
@@ -538,6 +550,9 @@ class StepExecutor:
             )
             constraints = constraints or "- 현재 step 파일에 명시된 범위를 벗어나지 마라."
             step_contract += f"## Hard constraints\n\n{constraints}\n\n"
+            metadata = self._task_metadata(step)
+            if metadata:
+                step_contract += f"## Task metadata\n\n{metadata}\n\n"
         return (
             f"당신은 {self._project} 프로젝트의 개발자입니다. 아래 step을 수행하세요.\n\n"
             f"{guardrails}\n\n---\n\n"
@@ -555,6 +570,20 @@ class StepExecutor:
             "6. 모든 변경사항을 커밋하라:\n"
             f"   {commit_example}\n\n---\n\n"
         )
+
+    @staticmethod
+    def _task_metadata(step: dict) -> str:
+        """Render v2 outcome metadata without changing the v1 prompt shape."""
+        if "id" not in step:
+            return ""
+        dependencies = step.get("dependsOn", [])
+        dependency_text = ", ".join(f"`{item}`" for item in dependencies) if dependencies else "없음"
+        lines = [f"- id: `{step['id']}`", f"- dependsOn: {dependency_text}"]
+        if step.get("issue") is not None:
+            lines.append(f"- issue: #{step['issue']}")
+        if step.get("risk") is not None:
+            lines.append(f"- risk: {step['risk']}")
+        return "\n".join(lines)
 
     # --- Codex 호출 ---
 
@@ -634,7 +663,7 @@ class StepExecutor:
         print(f"{'='*60}")
 
     def _check_blockers(self):
-        index = self._read_json(self._index_file)
+        index = self._read_phase_index()
         for s in reversed(index["steps"]):
             if s["status"] == "error":
                 print(f"\n  ✗ Step {s['step']} ({s['name']}) failed.")
@@ -650,7 +679,7 @@ class StepExecutor:
                 break
 
     def _ensure_created_at(self):
-        index = self._read_json(self._index_file)
+        index = self._read_phase_index()
         if "created_at" not in index:
             index["created_at"] = self._stamp()
             self._write_json(self._index_file, index)
@@ -660,11 +689,11 @@ class StepExecutor:
     def _execute_single_step(self, step: dict, guardrails: str, command_context: str) -> bool:
         """단일 step 실행 (재시도 포함). 완료되면 True, 실패/차단이면 False."""
         step_num, step_name = step["step"], step["name"]
-        done = sum(1 for s in self._read_json(self._index_file)["steps"] if s["status"] == "completed")
+        done = sum(1 for s in self._read_phase_index()["steps"] if s["status"] == "completed")
         prev_error = None
 
         for attempt in range(1, self.MAX_RETRIES + 1):
-            index = self._read_json(self._index_file)
+            index = self._read_phase_index()
             step_context = self._build_step_context(index)
             try:
                 preamble = self._build_preamble(
@@ -686,7 +715,7 @@ class StepExecutor:
                 self._invoke_codex(step, preamble)
                 elapsed = int(pi.elapsed)
 
-            index = self._read_json(self._index_file)
+            index = self._read_phase_index()
             status = next((s.get("status", "pending") for s in index["steps"] if s["step"] == step_num), "pending")
             ts = self._stamp()
 
@@ -749,7 +778,7 @@ class StepExecutor:
 
     def _execute_all_steps(self, guardrails: str, command_context: str):
         while True:
-            index = self._read_json(self._index_file)
+            index = self._read_phase_index()
             pending = next((s for s in index["steps"] if s["status"] == "pending"), None)
             if pending is None:
                 print("\n  All steps completed!")
@@ -771,7 +800,7 @@ class StepExecutor:
             return False
 
         step_num = step["step"]
-        index = self._read_json(self._index_file)
+        index = self._read_phase_index()
         for s in index["steps"]:
             if s["step"] == step_num and "started_at" not in s:
                 s["started_at"] = self._stamp()
@@ -782,7 +811,7 @@ class StepExecutor:
         return True
 
     def _select_single_step(self) -> Optional[dict]:
-        index = self._read_json(self._index_file)
+        index = self._read_phase_index()
         steps = index["steps"]
         pending = next((s for s in steps if s["status"] == "pending"), None)
         if pending is None:
@@ -833,7 +862,7 @@ class StepExecutor:
         return None
 
     def _has_pending_steps(self) -> bool:
-        index = self._read_json(self._index_file)
+        index = self._read_phase_index()
         return any(s.get("status") == "pending" for s in index["steps"])
 
     def _push_current_branch(self):
@@ -874,7 +903,7 @@ class StepExecutor:
             sys.exit(result.returncode)
 
     def _finalize(self):
-        index = self._read_json(self._index_file)
+        index = self._read_phase_index()
         index["completed_at"] = self._stamp()
         self._write_json(self._index_file, index)
         self._update_top_index("completed")
@@ -929,16 +958,20 @@ def main(argv: list[str] | None = None):
     except ValueError as exc:
         parser.error(str(exc))
 
-    StepExecutor(
-        args.phase_dir,
-        auto_push=args.push,
-        unsafe=args.unsafe,
-        branch_name=args.branch,
-        step_number=args.step,
-        next_step_only=args.next_step_only,
-        codex_effort=args.codex_effort,
-        allow_xhigh=args.allow_xhigh,
-    ).run()
+    try:
+        StepExecutor(
+            args.phase_dir,
+            auto_push=args.push,
+            unsafe=args.unsafe,
+            branch_name=args.branch,
+            step_number=args.step,
+            next_step_only=args.next_step_only,
+            codex_effort=args.codex_effort,
+            allow_xhigh=args.allow_xhigh,
+        ).run()
+    except task_schema.TaskSchemaError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
 
 
 if __name__ == "__main__":

--- a/scripts/task_schema.py
+++ b/scripts/task_schema.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Validate and normalize Harness phase task indexes.
+
+The template has two input formats:
+
+* v1: ``steps[]`` entries with ``step``, ``name`` and ``status``.
+* v2: ``schemaVersion: 2`` and ``tasks[]`` entries with outcome metadata.
+
+The normalized view always exposes the v1-shaped ``steps`` list to callers.  A
+writer can serialize the view back to the original shape, so merely reading a
+v1 or v2 index never performs a migration.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+SCHEMA_VERSION_KEY = "schemaVersion"
+SCHEMA_V1 = 1
+SCHEMA_V2 = 2
+VALID_STATUSES = frozenset({"pending", "completed", "error", "blocked"})
+
+V1_TASK_KEY = "steps"
+V2_TASK_KEY = "tasks"
+V2_REQUIRED_TASK_FIELDS = frozenset({"id", "objective", "status"})
+V2_OPTIONAL_TASK_FIELDS = frozenset({"dependsOn", "issue", "risk"})
+LIFECYCLE_FIELDS = frozenset(
+    {
+        "summary",
+        "error_message",
+        "blocked_reason",
+        "started_at",
+        "completed_at",
+        "failed_at",
+        "blocked_at",
+    }
+)
+V2_ALLOWED_TASK_FIELDS = V2_REQUIRED_TASK_FIELDS | V2_OPTIONAL_TASK_FIELDS | LIFECYCLE_FIELDS
+TOP_LEVEL_PERSISTABLE_FIELDS = frozenset({"created_at", "completed_at"})
+NORMALIZED_ALIAS_FIELDS = frozenset({"step", "name"})
+
+
+class SchemaIssue:
+    """One path-specific schema validation failure."""
+
+    __slots__ = ("path", "reason")
+
+    def __init__(self, path: str, reason: str):
+        self.path = path
+        self.reason = reason
+
+    def __str__(self) -> str:
+        return f"{self.path}: {self.reason}"
+
+
+class TaskSchemaError(ValueError):
+    """Raised when a phase index cannot be safely read by Harness."""
+
+    def __init__(self, errors: Iterable[SchemaIssue] | SchemaIssue | str):
+        if isinstance(errors, str):
+            normalized = (SchemaIssue("index.json", errors),)
+        elif isinstance(errors, SchemaIssue):
+            normalized = (errors,)
+        else:
+            normalized = tuple(errors)
+        if not normalized:
+            normalized = (SchemaIssue("index.json", "schema validation failed"),)
+        self.errors = normalized
+        self.issues = normalized
+        self.path = normalized[0].path
+        self.reason = normalized[0].reason
+        message = "phase index schema validation failed:\n" + "\n".join(
+            f"- {error}" for error in normalized
+        )
+        super().__init__(message)
+
+
+class NormalizedTask(dict[str, Any]):
+    """Dictionary-like task view with the source fields needed for round-trip writes."""
+
+    def __init__(
+        self,
+        values: Mapping[str, Any],
+        *,
+        source_index: int,
+        source_keys: Iterable[str],
+        persistable_keys: Iterable[str],
+    ):
+        super().__init__(copy.deepcopy(dict(values)))
+        self.source_index = source_index
+        self.source_keys = frozenset(source_keys)
+        self.persistable_keys = frozenset(persistable_keys)
+
+
+class NormalizedPhaseIndex(dict[str, Any]):
+    """Validated phase index with a common serial execution view.
+
+    ``normalized["steps"]`` is the canonical list consumed by the current
+    serial executor.  For v2 it is an in-memory alias only; ``to_payload``
+    writes ``tasks[]`` and never writes synthetic ``step``/``name`` aliases.
+    """
+
+    def __init__(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        schema_version: int,
+        task_key: str,
+        tasks: list[NormalizedTask],
+    ):
+        self.schema_version = schema_version
+        self.format_name = f"v{schema_version}"
+        self.task_key = task_key
+        self._raw_payload = copy.deepcopy(dict(payload))
+        super().__init__(copy.deepcopy(dict(payload)))
+        # Both names are available to callers, but only the original source
+        # key is serialized by to_payload().
+        self["steps"] = tasks
+        self["tasks"] = tasks
+
+    @property
+    def tasks(self) -> list[NormalizedTask]:
+        return self["steps"]
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return the original v1/v2 shape with lifecycle changes applied."""
+        payload = copy.deepcopy(self._raw_payload)
+
+        for key, value in self.items():
+            if key in {V1_TASK_KEY, V2_TASK_KEY}:
+                continue
+            if key in payload or key in TOP_LEVEL_PERSISTABLE_FIELDS:
+                payload[key] = copy.deepcopy(value)
+
+        source_tasks = payload[self.task_key]
+        for task, source in zip(self.tasks, source_tasks):
+            if not isinstance(source, dict):
+                continue
+            for key in list(source):
+                if key not in task:
+                    source.pop(key, None)
+                elif key in task.source_keys:
+                    source[key] = copy.deepcopy(task[key])
+            for key in task.persistable_keys:
+                if key in task and key not in source and key not in NORMALIZED_ALIAS_FIELDS:
+                    source[key] = copy.deepcopy(task[key])
+
+        return payload
+
+
+def normalize_phase_index(
+    payload: Mapping[str, Any],
+    *,
+    path: str | Path = "index.json",
+) -> NormalizedPhaseIndex:
+    """Validate an index payload and return a non-migrating normalized view."""
+    display_path = str(path).replace("\\", "/")
+    errors: list[SchemaIssue] = []
+    if not isinstance(payload, Mapping):
+        raise TaskSchemaError(SchemaIssue(display_path, "index must contain a JSON object"))
+
+    version, task_key = _detect_schema(payload, display_path, errors)
+    _validate_top_level(payload, version, task_key, display_path, errors)
+    raw_tasks = payload.get(task_key) if task_key else None
+    if not isinstance(raw_tasks, list):
+        if task_key:
+            errors.append(
+                SchemaIssue(
+                    f"{display_path} {task_key}",
+                    f"{task_key} must be a non-empty list",
+                )
+            )
+        raise TaskSchemaError(errors)
+    if not raw_tasks:
+        errors.append(SchemaIssue(f"{display_path} {task_key}", f"{task_key} must be a non-empty list"))
+
+    tasks: list[NormalizedTask] = []
+    ids: dict[str, str] = {}
+    for index, raw_task in enumerate(raw_tasks):
+        task_path = f"{display_path} {task_key}[{index}]"
+        if version == SCHEMA_V1:
+            task = _normalize_v1_task(raw_task, index, task_path, errors)
+        else:
+            task = _normalize_v2_task(raw_task, index, task_path, errors)
+        if task is None:
+            continue
+        tasks.append(task)
+
+        if version == SCHEMA_V2:
+            task_id = task.get("id")
+            id_path = f"{task_path}.id"
+            if isinstance(task_id, str):
+                previous_path = ids.get(task_id)
+                if previous_path is not None:
+                    errors.append(
+                        SchemaIssue(
+                            id_path,
+                            f"duplicate id '{task_id}' (already declared at {previous_path})",
+                        )
+                    )
+                else:
+                    ids[task_id] = id_path
+
+    if version == SCHEMA_V2:
+        _validate_dependencies(tasks, ids, display_path, task_key, errors)
+
+    if errors:
+        raise TaskSchemaError(errors)
+
+    return NormalizedPhaseIndex(
+        payload,
+        schema_version=version,
+        task_key=task_key,
+        tasks=tasks,
+    )
+
+
+def validate_phase_index(
+    payload: Mapping[str, Any],
+    *,
+    path: str | Path = "index.json",
+) -> NormalizedPhaseIndex:
+    """Explicit alias for callers that want to emphasize validation."""
+    return normalize_phase_index(payload, path=path)
+
+
+def load_phase_index(path: Path, *, display_path: str | Path | None = None) -> NormalizedPhaseIndex:
+    """Read, parse, validate and normalize an index file."""
+    shown_path = display_path if display_path is not None else path
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        shown = str(shown_path).replace("\\", "/")
+        raise TaskSchemaError(SchemaIssue(shown, f"invalid JSON: {exc}")) from exc
+    return normalize_phase_index(payload, path=shown_path)
+
+
+def tasks_from_index(
+    index: Mapping[str, Any],
+    *,
+    path: str | Path = "index.json",
+) -> list[NormalizedTask]:
+    """Return normalized serial tasks for a raw or already-normalized payload."""
+    if isinstance(index, NormalizedPhaseIndex):
+        return index.tasks
+    return normalize_phase_index(index, path=path).tasks
+
+
+def _detect_schema(
+    payload: Mapping[str, Any],
+    display_path: str,
+    errors: list[SchemaIssue],
+) -> tuple[int | None, str | None]:
+    marker = payload.get(SCHEMA_VERSION_KEY)
+    if SCHEMA_VERSION_KEY in payload and (isinstance(marker, bool) or not isinstance(marker, int)):
+        errors.append(SchemaIssue(f"{display_path}.{SCHEMA_VERSION_KEY}", "must be an integer 1 or 2"))
+        return None, None
+    if marker is not None and marker not in {SCHEMA_V1, SCHEMA_V2}:
+        errors.append(SchemaIssue(f"{display_path}.{SCHEMA_VERSION_KEY}", "must be 1 or 2"))
+        return None, None
+
+    has_steps = V1_TASK_KEY in payload
+    has_tasks = V2_TASK_KEY in payload
+    if has_steps and has_tasks:
+        if marker == SCHEMA_V2:
+            errors.append(
+                SchemaIssue(
+                    display_path,
+                    "schemaVersion 2 requires `tasks` and cannot contain `steps`",
+                )
+            )
+        else:
+            errors.append(
+                SchemaIssue(display_path, "define exactly one of `steps` (v1) or `tasks` (v2)")
+            )
+        return None, None
+
+    if marker == SCHEMA_V1:
+        if not has_steps:
+            errors.append(SchemaIssue(display_path, "schemaVersion 1 requires `steps`"))
+        return SCHEMA_V1, V1_TASK_KEY
+    if marker == SCHEMA_V2:
+        if not has_tasks:
+            errors.append(SchemaIssue(display_path, "schemaVersion 2 requires `tasks`"))
+        return SCHEMA_V2, V2_TASK_KEY
+    if has_steps:
+        return SCHEMA_V1, V1_TASK_KEY
+    if has_tasks:
+        return SCHEMA_V2, V2_TASK_KEY
+
+    errors.append(SchemaIssue(display_path, "must define `steps` (v1) or `tasks` (v2)"))
+    return None, None
+
+
+def _validate_top_level(
+    payload: Mapping[str, Any],
+    version: int | None,
+    task_key: str | None,
+    display_path: str,
+    errors: list[SchemaIssue],
+) -> None:
+    for key in ("project", "phase"):
+        if key in payload and not _non_empty_string(payload[key]):
+            errors.append(SchemaIssue(f"{display_path}.{key}", f"{key} must be a non-empty string"))
+
+    for key in TOP_LEVEL_PERSISTABLE_FIELDS:
+        if key in payload and not isinstance(payload[key], str):
+            errors.append(SchemaIssue(f"{display_path}.{key}", f"{key} must be a string"))
+
+    if version == SCHEMA_V2:
+        supported = {
+            SCHEMA_VERSION_KEY,
+            "project",
+            "phase",
+            V2_TASK_KEY,
+            *TOP_LEVEL_PERSISTABLE_FIELDS,
+        }
+        for key in payload:
+            if key not in supported:
+                errors.append(SchemaIssue(f"{display_path}.{key}", f"unsupported v2 field '{key}'"))
+
+
+def _normalize_v1_task(
+    raw_task: Any,
+    index: int,
+    task_path: str,
+    errors: list[SchemaIssue],
+) -> NormalizedTask | None:
+    if not isinstance(raw_task, Mapping):
+        errors.append(SchemaIssue(task_path, "step must be an object"))
+        return None
+
+    values = dict(raw_task)
+    step = values.get("step")
+    name = values.get("name")
+    status = values.get("status")
+    valid = True
+    if isinstance(step, bool) or not isinstance(step, int) or step < 0:
+        errors.append(SchemaIssue(f"{task_path}.step", "step must be a non-negative integer"))
+        valid = False
+    if not _non_empty_string(name):
+        errors.append(SchemaIssue(f"{task_path}.name", "name must be a non-empty string"))
+        valid = False
+    if status not in VALID_STATUSES:
+        label = step if isinstance(step, int) and not isinstance(step, bool) else index
+        errors.append(
+            SchemaIssue(
+                f"{task_path}.status",
+                f"step {label} status must be one of {', '.join(sorted(VALID_STATUSES))}",
+            )
+        )
+        valid = False
+    if not valid:
+        return None
+
+    values["id"] = name
+    values["objective"] = values.get("objective")
+    values["dependsOn"] = values.get("dependsOn", [])
+    return NormalizedTask(
+        values,
+        source_index=index,
+        source_keys=raw_task.keys(),
+        persistable_keys=set(raw_task.keys()) | LIFECYCLE_FIELDS,
+    )
+
+
+def _normalize_v2_task(
+    raw_task: Any,
+    index: int,
+    task_path: str,
+    errors: list[SchemaIssue],
+) -> NormalizedTask | None:
+    if not isinstance(raw_task, Mapping):
+        errors.append(SchemaIssue(task_path, "task must be an object"))
+        return None
+
+    values = dict(raw_task)
+    valid = True
+    unknown = set(values) - V2_ALLOWED_TASK_FIELDS
+    for key in sorted(unknown):
+        errors.append(SchemaIssue(f"{task_path}.{key}", f"unsupported v2 task field '{key}'"))
+        valid = False
+
+    for field in sorted(V2_REQUIRED_TASK_FIELDS):
+        if field not in values:
+            errors.append(SchemaIssue(f"{task_path}.{field}", f"{field} is required"))
+            valid = False
+
+    task_id = values.get("id")
+    if "id" in values and not _non_empty_string(task_id):
+        errors.append(SchemaIssue(f"{task_path}.id", "id must be a string"))
+        valid = False
+
+    objective = values.get("objective")
+    if "objective" in values and not _non_empty_string(objective):
+        errors.append(SchemaIssue(f"{task_path}.objective", "objective must be a string"))
+        valid = False
+
+    status = values.get("status")
+    if status not in VALID_STATUSES:
+        errors.append(
+            SchemaIssue(
+                f"{task_path}.status",
+                f"status must be one of {', '.join(sorted(VALID_STATUSES))}",
+            )
+        )
+        valid = False
+
+    depends_on = values.get("dependsOn", [])
+    if not isinstance(depends_on, list):
+        errors.append(SchemaIssue(f"{task_path}.dependsOn", "dependsOn must be a list"))
+        valid = False
+    else:
+        dependency_ids: set[str] = set()
+        for dep_index, dependency in enumerate(depends_on):
+            dependency_path = f"{task_path}.dependsOn[{dep_index}]"
+            if not _non_empty_string(dependency):
+                errors.append(SchemaIssue(dependency_path, "dependency id must be a string"))
+                valid = False
+                continue
+            if dependency in dependency_ids:
+                errors.append(SchemaIssue(dependency_path, f"duplicate dependency '{dependency}'"))
+                valid = False
+            dependency_ids.add(dependency)
+
+    if "issue" in values:
+        issue = values["issue"]
+        if isinstance(issue, bool) or not isinstance(issue, int) or issue <= 0:
+            errors.append(SchemaIssue(f"{task_path}.issue", "issue must be a positive integer"))
+            valid = False
+
+    if "risk" in values and not _non_empty_string(values["risk"]):
+        errors.append(SchemaIssue(f"{task_path}.risk", "risk must be a string"))
+        valid = False
+
+    for field in LIFECYCLE_FIELDS:
+        if field in values and not isinstance(values[field], str):
+            errors.append(SchemaIssue(f"{task_path}.{field}", f"{field} must be a string"))
+            valid = False
+
+    if not valid:
+        return None
+
+    values["dependsOn"] = list(depends_on)
+    # The existing executor still addresses companion stepN.md files and runs
+    # serially. These aliases are only an in-memory compatibility view.
+    values["step"] = index
+    values["name"] = values["id"]
+    return NormalizedTask(
+        values,
+        source_index=index,
+        source_keys=raw_task.keys(),
+        persistable_keys=set(raw_task.keys()) | LIFECYCLE_FIELDS,
+    )
+
+
+def _validate_dependencies(
+    tasks: list[NormalizedTask],
+    ids: Mapping[str, str],
+    display_path: str,
+    task_key: str,
+    errors: list[SchemaIssue],
+) -> None:
+    for task in tasks:
+        index = task.source_index
+        task_id = task.get("id")
+        for dep_index, dependency in enumerate(task.get("dependsOn", [])):
+            dependency_path = f"{display_path} {task_key}[{index}].dependsOn[{dep_index}]"
+            if not isinstance(dependency, str):
+                continue
+            if dependency == task_id:
+                errors.append(SchemaIssue(dependency_path, "self dependency is not allowed"))
+            elif dependency not in ids:
+                errors.append(
+                    SchemaIssue(
+                        dependency_path,
+                        f"unknown task id '{dependency}'",
+                    )
+                )
+
+
+def _non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())

--- a/scripts/tests/test_autopilot.py
+++ b/scripts/tests/test_autopilot.py
@@ -85,6 +85,44 @@ def test_preconditions_stop_on_gh_auth_failure(runner):
     assert "gh auth failed" in str(exc_info.value)
 
 
+def test_preconditions_reject_invalid_v2_before_github_or_codex(runner, tmp_repo):
+    index_path = tmp_repo / "phases" / "0-mvp" / "index.json"
+    index_path.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 2,
+                "project": "Demo",
+                "phase": "0-mvp",
+                "tasks": [
+                    {
+                        "id": "same",
+                        "objective": "첫 결과를 만든다.",
+                        "dependsOn": [],
+                        "status": "pending",
+                    },
+                    {
+                        "id": "same",
+                        "objective": "두 번째 결과를 만든다.",
+                        "dependsOn": [],
+                        "status": "pending",
+                    },
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    runner._git = lambda *args, check=True: cp(stdout="")
+
+    def unexpected_gh(*args, check=True, timeout=None):
+        raise AssertionError("GitHub authentication must not run for an invalid phase index")
+
+    runner._gh = unexpected_gh
+
+    with pytest.raises(ap.AutopilotError, match=r"tasks\[1\]\.id.*duplicate id"):
+        runner._ensure_preconditions()
+
+
 def test_step_success_creates_draft_pr_comments_and_merges(runner, tmp_repo):
     gh_calls = []
     executed = []

--- a/scripts/tests/test_doctor.py
+++ b/scripts/tests/test_doctor.py
@@ -78,6 +78,7 @@ def _write_template_files(root: Path):
     )
     _write_cross_platform_hook_contract(root)
     _write_example_phase(root)
+    _write_v2_example_phase(root)
 
 
 def _write_example_phase(root: Path):
@@ -122,6 +123,65 @@ def _write_example_phase(root: Path):
         json.dumps(
             {
                 "paths": ["phases/0-example"],
+                "required": [{"name": "goal", "pattern": "^## 목표$"}],
+                "finalRequired": [{"name": "done", "pattern": "^## 완료 기준$"}],
+                "forbidden": [{"name": "stale", "pattern": "deprecated-example-api"}],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    (phase_dir / "scope-rules.json").write_text(
+        json.dumps(
+            {
+                "extraForbidden": [{"message": "범위 밖 기능", "anyLowered": ["sync-service"]}],
+                "allowedScopeMessages": [{"message": "범위 밖 기능", "steps": [0]}],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_v2_example_phase(root: Path):
+    phase_dir = root / "phases" / "0-example-v2"
+    phase_dir.mkdir(parents=True, exist_ok=True)
+    (phase_dir / "README.md").write_text(
+        "# Phase: 0-example-v2\n\n## 목표\n- v2 예시\n\n## 완료 기준\n- 예시 기준\n",
+        encoding="utf-8",
+    )
+    (phase_dir / "index.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 2,
+                "project": "<프로젝트명>",
+                "phase": "0-example-v2",
+                "tasks": [
+                    {
+                        "id": "project-setup",
+                        "objective": "예시 결과를 만든다.",
+                        "dependsOn": [],
+                        "issue": 16,
+                        "risk": "low",
+                        "status": "pending",
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    (phase_dir / "step0.md").write_text(
+        "# 단계 0: project-setup\n\n"
+        "## 작업\n예시 결과를 만든다.\n\n"
+        "## 인수 기준\n\n```bash\npython scripts/checks.py --stage manual\n```\n\n"
+        "## 금지사항\n- 범위 밖 기능을 추가하지 마라.\n",
+        encoding="utf-8",
+    )
+    (phase_dir / "docs-checks.json").write_text(
+        json.dumps(
+            {
+                "paths": ["phases/0-example-v2"],
                 "required": [{"name": "goal", "pattern": "^## 목표$"}],
                 "finalRequired": [{"name": "done", "pattern": "^## 완료 기준$"}],
                 "forbidden": [{"name": "stale", "pattern": "deprecated-example-api"}],
@@ -330,6 +390,45 @@ def test_template_mode_detects_example_index_schema_violations(tmp_path, monkeyp
     assert any("`phase` must match the directory name" in issue for issue in issues)
     assert any("step 1 status must be one of" in issue for issue in issues)
     assert "phases/0-example/step1.md is missing." in issues
+
+
+def test_template_mode_detects_v2_schema_violations(tmp_path, monkeypatch):
+    _write_template_files(tmp_path)
+    monkeypatch.setattr(doctor, "_git_hooks_path", lambda root=tmp_path: "")
+    (tmp_path / "phases" / "0-example-v2" / "index.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 2,
+                "project": "Demo",
+                "phase": "0-example-v2",
+                "tasks": [
+                    {
+                        "id": "same",
+                        "objective": "첫 결과",
+                        "dependsOn": [],
+                        "status": "pending",
+                    },
+                    {
+                        "id": "same",
+                        "objective": "두 번째 결과",
+                        "dependsOn": [],
+                        "status": "pending",
+                    },
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    issues = doctor.collect_issues(tmp_path, "template")
+
+    assert any(
+        "phases/0-example-v2/index.json" in issue
+        and "tasks[1].id" in issue
+        and "duplicate id" in issue
+        for issue in issues
+    )
 
 
 def test_template_mode_detects_example_step_without_acceptance_commands(tmp_path, monkeypatch):

--- a/scripts/tests/test_execute.py
+++ b/scripts/tests/test_execute.py
@@ -12,6 +12,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 import execute as ex
+import task_schema
 
 
 # ---------------------------------------------------------------------------
@@ -169,6 +170,82 @@ class TestJsonHelpers:
     def test_load_nonexistent_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             ex.StepExecutor._read_json(tmp_path / "nope.json")
+
+
+class TestTaskSchemaIntegration:
+    def test_executor_accepts_v2_and_keeps_serial_list_order(self, tmp_project):
+        phase = tmp_project / "phases" / "0-v2"
+        phase.mkdir()
+        (phase / "index.json").write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 2,
+                    "project": "Demo",
+                    "phase": "0-v2",
+                    "tasks": [
+                        {
+                            "id": "first",
+                            "objective": "첫 번째 결과를 만든다.",
+                            "dependsOn": [],
+                            "status": "pending",
+                        },
+                        {
+                            "id": "second",
+                            "objective": "두 번째 결과를 만든다.",
+                            "dependsOn": ["first"],
+                            "status": "pending",
+                        },
+                    ],
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        (phase / "step0.md").write_text("# Step 0\n", encoding="utf-8")
+        (phase / "step1.md").write_text("# Step 1\n", encoding="utf-8")
+
+        with patch.object(ex, "ROOT", tmp_project):
+            instance = ex.StepExecutor("0-v2", next_step_only=True)
+
+        selected = instance._select_single_step()
+
+        assert selected["step"] == 0
+        assert selected["name"] == "first"
+        assert selected["objective"] == "첫 번째 결과를 만든다."
+        assert selected["dependsOn"] == []
+
+    def test_invalid_v2_index_is_rejected_before_codex(self, tmp_project):
+        phase = tmp_project / "phases" / "0-invalid"
+        phase.mkdir()
+        (phase / "index.json").write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 2,
+                    "project": "Demo",
+                    "phase": "0-invalid",
+                    "tasks": [
+                        {
+                            "id": "same",
+                            "objective": "결과를 만든다.",
+                            "dependsOn": [],
+                            "status": "pending",
+                        },
+                        {
+                            "id": "same",
+                            "objective": "다른 결과를 만든다.",
+                            "dependsOn": [],
+                            "status": "pending",
+                        },
+                    ],
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.object(ex, "ROOT", tmp_project):
+            with pytest.raises(task_schema.TaskSchemaError, match=r"tasks\[1\]\.id.*duplicate id"):
+                ex.StepExecutor("0-invalid")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_task_schema.py
+++ b/scripts/tests/test_task_schema.py
@@ -1,0 +1,193 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import task_schema
+
+
+def v1_index():
+    return {
+        "project": "Demo",
+        "phase": "0-example",
+        "steps": [
+            {"step": 0, "name": "setup", "status": "completed", "summary": "골격 완료"},
+            {"step": 1, "name": "feature", "status": "pending"},
+        ],
+    }
+
+
+def v2_index():
+    return {
+        "schemaVersion": 2,
+        "project": "Demo",
+        "phase": "0-v2-example",
+        "tasks": [
+            {
+                "id": "setup",
+                "objective": "프로젝트 골격을 완성한다.",
+                "dependsOn": [],
+                "issue": 16,
+                "risk": "low",
+                "status": "completed",
+                "summary": "골격 완료",
+            },
+            {
+                "id": "feature",
+                "objective": "핵심 기능을 완성한다.",
+                "dependsOn": ["setup"],
+                "risk": "medium",
+                "status": "pending",
+            },
+        ],
+    }
+
+
+def assert_schema_error(payload, expected):
+    with pytest.raises(task_schema.TaskSchemaError) as exc_info:
+        task_schema.normalize_phase_index(payload, path="phases/0-v2-example/index.json")
+    message = str(exc_info.value)
+    for fragment in expected:
+        assert fragment in message
+    return exc_info.value
+
+
+def test_normalizes_v1_without_mutating_or_migrating_payload():
+    payload = v1_index()
+    original = json.loads(json.dumps(payload, ensure_ascii=False))
+
+    normalized = task_schema.normalize_phase_index(payload, path="phases/0-example/index.json")
+
+    assert normalized.schema_version == 1
+    assert normalized.format_name == "v1"
+    assert normalized.task_key == "steps"
+    assert [(task["step"], task["name"], task["status"]) for task in normalized["steps"]] == [
+        (0, "setup", "completed"),
+        (1, "feature", "pending"),
+    ]
+    assert payload == original
+    assert normalized.to_payload() == original
+
+
+def test_normalizes_v2_outcome_fields_and_preserves_v2_shape():
+    payload = v2_index()
+
+    normalized = task_schema.normalize_phase_index(payload, path="phases/0-v2-example/index.json")
+
+    assert normalized.schema_version == 2
+    assert normalized.format_name == "v2"
+    assert normalized.task_key == "tasks"
+    assert normalized["steps"][0]["step"] == 0
+    assert normalized["steps"][0]["name"] == "setup"
+    assert normalized["steps"][1]["id"] == "feature"
+    assert normalized["steps"][1]["objective"] == "핵심 기능을 완성한다."
+    assert normalized["steps"][1]["dependsOn"] == ["setup"]
+    assert normalized["steps"][0]["issue"] == 16
+    assert normalized["steps"][0]["risk"] == "low"
+    assert normalized.to_payload() == payload
+    assert "steps" not in normalized.to_payload()
+
+
+def test_v2_defaults_missing_dependencies_to_empty_list():
+    payload = v2_index()
+    del payload["tasks"][1]["dependsOn"]
+
+    normalized = task_schema.normalize_phase_index(payload)
+
+    assert normalized["steps"][1]["dependsOn"] == []
+    assert normalized.to_payload() == payload
+
+
+def test_normalized_v2_syncs_lifecycle_updates_without_writing_v1_aliases():
+    payload = v2_index()
+    normalized = task_schema.normalize_phase_index(payload)
+    normalized["steps"][1]["status"] = "completed"
+    normalized["steps"][1]["summary"] = "기능 완료"
+    normalized["completed_at"] = "2026-09-04T12:00:00+0900"
+
+    saved = normalized.to_payload()
+
+    assert saved["tasks"][1]["status"] == "completed"
+    assert saved["tasks"][1]["summary"] == "기능 완료"
+    assert saved["completed_at"] == "2026-09-04T12:00:00+0900"
+    assert "step" not in saved["tasks"][1]
+    assert "name" not in saved["tasks"][1]
+
+
+def test_duplicate_v2_ids_are_rejected_with_field_path():
+    payload = v2_index()
+    payload["tasks"][1]["id"] = "setup"
+
+    assert_schema_error(
+        payload,
+        ["phases/0-v2-example/index.json", "tasks[1].id", "duplicate id 'setup'"],
+    )
+
+
+def test_unknown_dependency_is_rejected_with_dependency_path():
+    payload = v2_index()
+    payload["tasks"][1]["dependsOn"] = ["missing"]
+
+    assert_schema_error(
+        payload,
+        ["tasks[1].dependsOn[0]", "unknown task id 'missing'"],
+    )
+
+
+def test_self_dependency_is_rejected_before_execution():
+    payload = v2_index()
+    payload["tasks"][1]["dependsOn"] = ["feature"]
+
+    assert_schema_error(
+        payload,
+        ["tasks[1].dependsOn[0]", "self dependency"],
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "reason"),
+    [
+        ("id", 1, "id must be a string"),
+        ("objective", ["outcome"], "objective must be a string"),
+        ("dependsOn", "setup", "dependsOn must be a list"),
+        ("issue", True, "issue must be a positive integer"),
+        ("risk", 3, "risk must be a string"),
+        ("status", "running", "status must be one of"),
+    ],
+)
+def test_v2_field_contract_rejects_wrong_types_or_status(field, value, reason):
+    payload = v2_index()
+    payload["tasks"][1][field] = value
+
+    assert_schema_error(payload, [f"tasks[1].{field}", reason])
+
+
+def test_v1_status_contract_is_shared_with_v2():
+    payload = v1_index()
+    payload["steps"][1]["status"] = "running"
+
+    error = assert_schema_error(
+        payload,
+        ["phases/0-v2-example/index.json", "step 1 status must be one of"],
+    )
+
+    assert set(task_schema.VALID_STATUSES) == {"pending", "completed", "error", "blocked"}
+    assert error.errors[0].path.endswith("steps[1].status")
+
+
+def test_schema_discriminator_rejects_mixed_or_unsupported_shapes():
+    mixed = v2_index()
+    mixed["steps"] = []
+    assert_schema_error(mixed, ["schemaVersion 2 requires `tasks` and cannot contain `steps`"])
+
+    unsupported = v1_index()
+    unsupported["schemaVersion"] = 3
+    assert_schema_error(unsupported, ["schemaVersion", "must be 1 or 2"])
+
+
+def test_load_phase_index_reports_json_path(tmp_path: Path):
+    path = tmp_path / "index.json"
+    path.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(task_schema.TaskSchemaError, match="phases/demo/index.json"):
+        task_schema.load_phase_index(path, display_path="phases/demo/index.json")


### PR DESCRIPTION
## 작업 내용

- Issue #16의 outcome task schema v2와 기존 v1 phase/index 호환을 구현했습니다.
- `scripts/task_schema.py`에 v1/v2 discriminator, 공통 status, 필수·선택 필드, 정규화와 path/reason 오류를 추가했습니다.
- `execute.py`, `autopilot.py`, `doctor.py`가 중복 id, missing/self/unknown dependency, 잘못된 타입·status를 Codex 호출 전에 같은 validator로 확인합니다.
- v2 예제, ADR, Harness/review skill, 운영 문서와 migration 규칙을 갱신했습니다.

## 호환성 및 범위

- 기존 `phases/0-example/index.json`은 변경하지 않았고 v1 `steps[]`를 계속 읽고 저장합니다.
- v2 `tasks[]`의 `id`, `objective`, `status`와 선택 `dependsOn`, `issue`, `risk`를 표현합니다.
- v2의 `step`/`name`은 현재 serial executor와 `stepN.md`를 연결하는 메모리 alias이며 JSON에 저장하지 않습니다.
- `dependsOn`은 이번 단계에서 dependency reference만 검증하며, list-order 실행은 유지합니다.
- DAG scheduler, ready set, cycle 실행, parallelism과 기존 phase 자동 migration은 구현하지 않았습니다. 해당 범위는 후속 #22 또는 명시적 opt-in migration 작업입니다.

## 테스트 및 확인

- PASS: `uv run --with pytest python -X utf8 -m pytest scripts` — 206 passed
- PASS: `uv run --with pytest python -X utf8 -m compileall -q scripts`
- PASS: `uv run --with pytest python -X utf8 scripts/doctor.py --template`
- PASS: `uv run --with pytest python -X utf8 scripts/checks.py --docs-check-config phases/harness-v2-modernization/docs-checks.json --docs-check`
- PASS: `git diff --check`
- 환경 제약: 지정 명령 `python -m pytest scripts`와 `python scripts/doctor.py --template`은 현재 PowerShell PATH에 `python`이 없어 시작되지 않았습니다. 동일 검증을 `uv run ... python -X utf8`로 수행했습니다.
- 참고: 템플릿의 `docs/COMMANDS.md`는 제품별 `test`/`build`가 의도적으로 비어 있어 `checks.py --stage manual/final`은 `Missing required check commands: test, build`로 종료합니다. 템플릿 설계상 상태이며 이번 schema 검증 실패가 아닙니다.

## 관련 이슈

Closes #16