### PR TITLE
feat: task worktree 격리 lifecycle 도입

### DIFF
--- a/.agents/skills/harness/SKILL.md
+++ b/.agents/skills/harness/SKILL.md
@@ -295,7 +295,7 @@ python scripts/autopilot.py {작업명} --dry-run --max-steps 1
 ```
 
 `scripts/execute.py`는 phase index를 `scripts/task_schema.py`로 먼저 검증한 뒤
-브랜치 생성, `AGENTS.md`·phase·관련 문서의 직접 읽기 경로 검증, 현재 step의
+현재 선택된 task branch를 확인하고, `AGENTS.md`·phase·관련 문서의 직접 읽기 경로 검증, 현재 step의
 objective/acceptance criteria/hard constraints와 완료된 단계의
 `summary` context 전달, 재시도 피드백, 코드 변경과 메타데이터의 2단계 커밋,
 completed 보고 후 인수 기준 재검증, 타임스탬프 기록, 선택적 push를 처리한다.
@@ -305,9 +305,25 @@ completed 보고 후 인수 기준 재검증, 타임스탬프 기록, 선택적 
 실행은 Codex 승인과 sandbox를 유지하며, 필요한 경우에만 `--unsafe`를 명시한다.
 `scripts/execute.py`는 `--step` 또는 `--next-step-only`가 아닌 전체 phase 실행에서 모든 pending step이 완료되면 `python scripts/checks.py --stage final`을 실행한다.
 
-`scripts/autopilot.py`는 clean worktree에서 다음 pending step을 `codex/{phase}-step{N}-{name}` 브랜치로 실행하고 Draft PR을 만든다. `--base`를 생략하면 origin HEAD를 사용하고 실패 시 `main`으로 fallback한다. step 인수 기준, diff check, scope rule scan, Codex read-only review, 원격 PR checks가 통과하면 ready 전환 후 squash merge한다. 실패하면 PR 코멘트, GitHub Issue, `issues/{phase}/issue-N.md`를 남기고 같은 PR 브랜치에서 제한 횟수만큼 자동 수정과 재리뷰를 수행한다. 재시도 후에도 실패하면 PR과 Issue를 열어둔 채 중단한다.
+`scripts/autopilot.py`는 clean primary checkout에서 base remote ref/SHA를 확인하고, 다음 pending step을 `codex/{phase}-step{N}-{name}` 브랜치의 Harness-owned task worktree에서 실행해 Draft PR을 만든다. `--base`를 생략하면 origin HEAD를 사용하고 실패 시 `main`으로 fallback한다. step 인수 기준, diff check, scope rule scan, Codex read-only review, 원격 PR checks가 통과하면 ready 전환 후 squash merge한다. 실패하면 marker·task worktree·PR 코멘트·GitHub Issue·`issues/{phase}/issue-N.md`를 남기고 같은 PR 브랜치에서 제한 횟수만큼 자동 수정과 재리뷰를 수행한다. 재시도 후에도 실패하면 PR과 Issue를 열어둔 채 중단한다.
 `scripts/autopilot.py`도 모든 pending step이 사라진 뒤 `python scripts/checks.py --stage final`로 phase-local `docs-checks.json`을 한 번 검증한다.
 
 phase별 범위 규칙이 필요하면 `phases/{작업명}/scope-rules.json`에 `extraForbidden` 또는 `allowedScopeMessages`를 추가한다. 전역 규칙은 `.codex/scope-rules.json`에 둔다. 템플릿 스크립트에 제품별 금지 키워드를 추가하지 않는다.
 
 복구가 필요하면 `phases/{작업명}/index.json`에서 실패 또는 blocked 상태의 단계를 다시 `pending`으로 바꾸고, `error_message` 또는 `blocked_reason`을 제거한 뒤 원인을 해결하고 페이즈를 다시 실행한다. v1/v2 index의 validation 오류는 path/reason과 함께 Codex 호출 전에 중단되며, 기존 phase 파일은 자동 migration하지 않는다.
+
+### Task worktree 실행 경계
+
+`autopilot.py`가 구현·검증·review·PR 준비를 task별 독립 worktree에서 수행할 때는
+`docs/WORKTREE_LIFECYCLE.md`와 ADR-0004를 먼저 읽는다. `scripts/worktree.py`가
+Git administrative directory의 `harness-worktree.json` marker에
+`owner=codex-harness`, `taskId`, phase, branch, 절대 path, `baseRef`, `baseSha`와
+상태·진단을 atomic하게 기록한다. marker 없는 path/branch, owner 불일치, stale
+administrative entry는 소유권을 추측하지 않고 보존한다.
+
+primary checkout은 branch switch/commit/stage 대상이 아니다. base sync와 PR merge는
+`.codex/autopilot.lock` 아래 동시성 1로 직렬화하고, v1 `steps[]`·v2 `tasks[]`는
+기존 list-order를 그대로 따른다. `error`, `blocked`, `interrupted` task는 marker와
+checkout을 남겨 같은 task를 resume하며, `merged`·clean·expected HEAD·active entry·
+Harness owner를 모두 확인한 경우에만 force 없는 safe cleanup을 수행한다. DAG,
+ready-set, parallelism과 사용자 worktree/branch 자동 삭제·prune은 이 단계에 넣지 않는다.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -42,6 +42,10 @@ description: "Codex가 이 Harness 기반 프로젝트의 변경사항을 AGENTS
    Codex/GitHub 호출 전에 파일 및 필드 경로와 reason으로 거부되는가?
 8. scope boundary: v2 alias가 저장 시 v1/v2 원형을 바꾸지 않고, #22의 DAG
    scheduler·ready set·cycle 처리·parallelism이나 자동 migration을 선행하지 않는가?
+9. worktree safety: `scripts/worktree.py`의 marker owner/task/path/branch/base SHA가
+   일치하는 경우만 resume하고, primary branch 불변·동시성 1·실패 보존·stale
+   administrative entry 진단·merged/clean/head 검증 뒤의 non-force cleanup을
+   지키는가? 사용자 worktree/branch를 자동 삭제·이동·prune하지 않는가?
 
 ### 출력
 
@@ -55,6 +59,7 @@ description: "Codex가 이 Harness 기반 프로젝트의 변경사항을 AGENTS
 | CRITICAL 규칙 | 통과/실패 | {상세} |
 | task schema와 pre-Codex 검증 | 통과/실패 | {v1/v2 contract, path/reason 오류, 실행 전 차단} |
 | 후속 범위 격리 | 통과/실패 | {DAG/parallel/migration 선행 여부} |
+| worktree 소유권·정리 안전성 | 통과/실패 | {primary 불변, marker, stale/실패 보존, cleanup gate} |
 | 빌드 가능 | 통과/실패 | {상세} |
 
 어떤 항목이라도 실패하면 파일 경로, 구체적인 문제, 수정 방안을 포함한다. 의존성이 없어서 검사를 실행하지 못한 경우에는 빌드 행에 그 사실을 명확히 적는다.

--- a/.codex/project-profile.json
+++ b/.codex/project-profile.json
@@ -1,6 +1,6 @@
 {
   "projectName": "<project-name>",
-  "templateVersion": "2026.09.04.1",
+  "templateVersion": "2026.09.04.2",
   "profile": "mixed",
   "guardMode": "soft",
   "commands": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@
   오류 테스트를 추가했습니다. v1→v2 자동 migration과 DAG/parallel 실행은
   포함하지 않습니다.
 
+## 2026.09.04.2
+
+### Added
+- `scripts/worktree.py`와 `docs/WORKTREE_LIFECYCLE.md`를 추가해 task별 Git
+  worktree의 create/list/resume/safe cleanup, owner marker, base ref/SHA와 실패
+  보존 계약을 정의했습니다.
+- primary checkout을 건드리지 않는 직렬 autopilot 경로와 Windows/stale/실패
+  복구·task isolation 검증을 추가합니다.
+
+### Changed
+- worktree 소유권이 확인된 merge 성공 task만 force 없는 정리 대상이 되며,
+  사용자 branch/worktree와 stale administrative entry는 자동 변경하지 않습니다.
+- `execute.py`는 task worktree worker로, `autopilot.py`는 base sync·merge를
+  repository lock 아래 직렬 조정 경로로 사용합니다.
+
 ## 2026.09.04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Codex 기반 개인 프로젝트 운영 템플릿입니다. 이 레포는 앱 �
 ```text
 ① 셋업    템플릿 복사 → Git hook 설정 → Plan Mode로 문서 채우기 → doctor 통과
 ② 설계    Harness skill로 MVP를 phase/step 문서로 분해
-③ 실행    execute.py로 step 구현, 또는 autopilot.py로 step별 PR 루프
-④ 검증    guard hook + checks + 자체 리뷰가 매 step의 범위와 품질을 지킴
+③ 실행    autopilot.py가 task worktree에서 구현·검증·review·PR을 직렬 수행
+④ 검증    guard hook + checks + 자체 리뷰가 매 task의 범위와 품질을 지킴
 ```
 
 각 단계에서 Codex에 복붙할 프롬프트는 [guides/PROMPTS.md](guides/PROMPTS.md)에
@@ -103,13 +103,19 @@ doctor가 통과한 뒤 Plan Mode에서 Harness skill로 phase/step 설계안을
 
 ## ③ 실행
 
-### execute.py — 로컬 step 실행
+### execute.py — 선택된 worktree에서 로컬 step 실행
 
 ```bash
 python scripts/execute.py {phase-name}                  # phase 전체
 python scripts/execute.py {phase-name} --next-step-only # 다음 step만
 python scripts/execute.py {phase-name} --push           # 실행 후 push
 ```
+
+`execute.py`는 이미 선택된 task worktree에서 실행하는 worker다. primary checkout의
+branch를 바꾸지 않으려면 `autopilot.py`를 사용하거나, `scripts/worktree.py`로
+Harness 소유 worktree를 먼저 만들고 그 경로에서 실행한다. worktree marker와
+resume/cleanup 규칙은 [docs/WORKTREE_LIFECYCLE.md](docs/WORKTREE_LIFECYCLE.md)에
+있다.
 
 ### autopilot.py — step별 PR 루프
 
@@ -121,7 +127,7 @@ Codex 호출 전에 공통 validator로 확인하며, v2의 `dependsOn`은 현�
 - `git status --short`가 비어 있는 clean worktree 상태임
 - `git remote get-url origin`이 성공함
 - `gh auth status`가 성공함
-- base branch가 `origin`과 fast-forward 동기화 가능한 상태임
+- base branch를 `fetch`한 뒤 remote ref와 전체 commit SHA를 확인할 수 있음
 - base 브랜치에서 `python scripts/checks.py --stage manual`이 통과함
   (의도적으로 생략하려면 `--skip-base-checks`)
 
@@ -129,13 +135,18 @@ Codex 호출 전에 공통 validator로 확인하며, v2의 `dependsOn`은 현�
 python scripts/autopilot.py {phase-name} --max-review-fixes 2  # phase 전체 구현 시 권장
 ```
 
-autopilot은 step마다 아래 루프를 반복합니다.
+autopilot은 task마다 아래 루프를 반복합니다.
 
-1. 다음 pending step을 `codex/{phase}-step{N}-{name}` 브랜치에서 실행하고 Draft PR을 만듭니다.
-2. step 인수 기준 명령 또는 `python scripts/checks.py --stage manual`, `git diff --check`, scope rule scan, Codex read-only review가 통과하면 PR을 ready로 전환합니다.
-3. PR ready 후 `gh pr checks --watch` 원격 체크가 통과해야 squash merge합니다. CI가 없는 저장소는 `--allow-no-checks`로 no-checks grace 대기를 생략할 수 있습니다.
-4. 리뷰가 실패하면 PR 코멘트, GitHub Issue, `issues/{phase}/issue-N.md`를 남기고 같은 PR 브랜치에서 자동 수정과 재리뷰를 진행합니다.
-5. 재시도 후에도 실패하면 PR과 Issue를 열어둔 채 중단합니다.
+1. base를 fetch하고 SHA를 고정한 뒤, 다음 pending task의
+   `codex/{phase}-step{N}-{name}` branch와 독립 worktree를 준비합니다.
+2. task worktree에서 구현·인수 기준·scope rule scan·Codex read-only review를
+   수행하고 Draft PR을 만듭니다.
+3. step 인수 기준 명령 또는 `python scripts/checks.py --stage manual`,
+   `git diff --check`가 통과하면 PR을 ready로 전환합니다.
+4. PR ready 후 `gh pr checks --watch` 원격 체크가 통과해야 squash merge하고,
+   merge된 Harness 소유 worktree만 안전 정리합니다.
+5. review/실행이 실패하면 marker·checkout·PR·Issue를 남겨 같은 task를 재개하고,
+   사용자 worktree/branch와 stale administrative entry는 자동 변경하지 않습니다.
 
 ## ④ 검증 장치
 
@@ -160,7 +171,7 @@ autopilot은 step마다 아래 루프를 반복합니다.
 | Codex 설정 | `.codex/` | hook 설정, project profile, scope rules |
 | Hook | `.githooks/pre-commit`, `.codex/hooks/` | 커밋 전 검증, cross-platform hook wrapper |
 | Skill | `.agents/skills/harness`, `.agents/skills/review` | phase/step 설계·실행, 문서 기준 자체 리뷰 워크플로우 |
-| 스크립트 | `scripts/`, `scripts/tests/` | `execute.py`, `autopilot.py`, `checks.py`, `doctor.py`, `task_schema.py`, `guard.py`, `upgrade.py`, `codex_common.py`, Harness 스크립트 테스트 |
+| 스크립트 | `scripts/`, `scripts/tests/` | `execute.py`, `autopilot.py`, `worktree.py`, `checks.py`, `doctor.py`, `task_schema.py`, `guard.py`, `upgrade.py`, `codex_common.py`, Harness 스크립트 테스트 |
 | 작업 공간 | `phases/`, `issues/`, `archive/` | v1/v2 phase 문서(예시: `phases/0-example/`, `phases/0-example-v2/`), 실패 기록, 직전 MVP 요약 |
 | CI | `.github/workflows/template-ci.yml` | macOS/Linux/Windows 템플릿 검증 (인스턴스에는 복사하지 않음) |
 | 메타 | `LICENSE`, `CHANGELOG.md` | MIT 라이선스, `templateVersion` 기준 변경 내역 |
@@ -187,7 +198,9 @@ python scripts/upgrade.py --from <template-checkout>            # 적용 + templ
 ```
 
 버전 사이의 계약 변화는 [CHANGELOG.md](CHANGELOG.md)에서, 파일 소유 구분과 전체
-절차는 [guides/UPGRADE.md](guides/UPGRADE.md)에서 확인합니다.
+절차는 [guides/UPGRADE.md](guides/UPGRADE.md)에서 확인합니다. task worktree의
+상태·소유권·정리 gate는 [docs/WORKTREE_LIFECYCLE.md](docs/WORKTREE_LIFECYCLE.md)를
+따릅니다.
 
 ## 템플릿 자체 개발
 

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -9,3 +9,4 @@
 - [ADR-0001: Harness Step PR Workflow](adr/0001-step-pr-workflow.md)
 - [ADR-0002: Codex subprocess 환경 상속 최소화](adr/0002-minimize-codex-environment.md)
 - [ADR-0003: Outcome task schema v2와 v1 호환](adr/0003-outcome-task-schema-v2.md)
+- [ADR-0004: Isolated task worktree lifecycle](adr/0004-isolated-task-worktrees.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,36 +1,77 @@
 # 아키텍처
 
 ## 시스템 개요
-- Runtime/Framework: <Spring Boot | Python | Node | 기타>
-- 주요 책임: <이 시스템이 맡는 핵심 책임>
-- 외부 의존성: <DB, API, queue, file system 등>
+
+- Runtime/Framework: Python CLI Harness
+- 주요 책임: phase task를 검증하고 Codex 구현·검증·review·PR 흐름을 안전하게
+  직렬 오케스트레이션한다.
+- 외부 의존성: Git, GitHub CLI, Codex CLI, 로컬 파일 시스템
 
 ## 디렉터리 구조
+
 ```text
-<프로젝트 구조를 실제 경로 기준으로 작성>
+scripts/
+  execute.py       # 한 task의 구현과 acceptance 재검증
+  autopilot.py     # task별 PR, review, merge 직렬 루프
+  worktree.py      # task worktree와 administrative marker lifecycle
+  task_schema.py   # v1/v2 phase index validator와 memory view
+  doctor.py        # template/instance readiness 검사
+docs/
+  WORKTREE_LIFECYCLE.md
+  adr/0004-isolated-task-worktrees.md
+phases/{phase}/
+  index.json, stepN.md, README.md, docs-checks.json
 ```
 
 ## 모듈 경계
-- <모듈/패키지/레이어 1>: <책임>
-- <모듈/패키지/레이어 2>: <책임>
-- <모듈/패키지/레이어 3>: <책임>
+
+- `task_schema.py`: v1 `steps[]`와 v2 `tasks[]`를 검증하고 list-order 공통 memory
+  view를 제공한다. DAG scheduler나 migration은 담당하지 않는다.
+- `worktree.py`: Git worktree add/list/resume/remove와 Harness 소유권 marker,
+  base SHA, 정리 gate를 담당한다. primary 파일과 사용자 branch를 수정하지 않는다.
+- `execute.py`: 이미 선택된 task worktree에서 Codex 구현, acceptance 재검증,
+  phase 상태 기록을 수행한다.
+- `autopilot.py`: primary의 repository lock 안에서 base fetch, worktree 준비,
+  execute subprocess, PR/review/merge, 성공 정리를 한 번에 하나씩 조정한다.
 
 ## 데이터 흐름
+
 ```text
-<입력> -> <처리 경계> -> <저장/외부 API> -> <응답/출력>
+phase index
+  -> task_schema validation
+  -> origin/<base> fetch + base SHA pin
+  -> isolated task worktree + admin marker
+  -> execute.py (implementation -> acceptance)
+  -> PR draft -> local/scope/read-only review -> ready -> CI -> squash merge
+  -> merged/clean/head/owner gate -> safe cleanup
 ```
 
+실패·blocked·중단은 `worktree.py` marker와 checkout에 남아 동일 task를 재개할 수
+있다. primary에서는 base branch를 checkout하거나 pull하지 않는다.
+
 ## 상태와 저장소
-- 영속 상태: <DB/table/file 등>
-- 임시 상태: <cache/session/memory 등>
-- 마이그레이션 전략: <필요 시 작성>
+
+- 영속 상태: phase index는 프로젝트 파일, task marker는 Git administrative
+  directory의 `harness-worktree.json`에 둔다.
+- 임시 상태: task worktree는 primary 밖의 managed root에 둔다.
+- 마이그레이션 전략: v1/v2 index와 사용자 worktree/branch는 자동 migration하지
+  않는다. marker가 없는 기존 checkout은 소유권을 추측하지 않고 보존한다.
 
 ## 오류 처리
-- 사용자 입력 오류: <처리 방식>
-- 외부 의존성 실패: <처리 방식>
-- 재시도/복구: <처리 방식>
+
+- schema/소유권/path 오류: Codex·GitHub 호출 전에 path/reason과 함께 fail-closed
+  한다.
+- Git/CI/review 실패: marker에 축약 진단을 남기고 task checkout을 보존한다.
+- stale administrative entry 또는 dirty/ignored 파일: prune/force 없이 중단하고
+  수동 확인을 요구한다.
+- 재시도/복구: `error`, `blocked`, `interrupted` 상태의 같은 marker만 검증 후
+  resume하며, 성공 merge 전에는 정리하지 않는다.
 
 ## 테스트 전략
-- 단위 테스트: <대상>
-- 통합 테스트: <대상>
-- 수동 검증: <필요 시 작성>
+
+- 단위 테스트: marker round-trip/atomic update, ownership, Windows·긴 경로,
+  stale/dirty/기존 branch/path와 execute/autopilot 호출 경계
+- 통합 테스트: 실제 임시 bare repository와 working repository에서 task 변경
+  격리, primary branch 불변, 직렬 v1/v2 실행, 성공/실패 정리
+- 수동 검증: `doctor.py --template`, 전체 `pytest scripts`, `compileall`,
+  phase docs-check와 `git diff --check`

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -74,6 +74,28 @@ autopilot 운영 안전장치:
 - `execute.py`의 guardrail prompt에는 문서 본문을 첨부하지 않고, Codex가 직접 읽어야 할 저장소 상대 경로만 기록한다. `guardrailDocs`가 비어 있지 않으면 그 목록을 우선하고, 비어 있거나 없으면 phase 문서 참조와 canonical 문서 fallback을 사용한다. 현재 step의 `읽어야 할 파일`도 경로 목록에 포함한다.
 - AGENTS, phase 문서, profile 또는 step이 지정한 경로가 누락되거나 읽을 수 없으면 Codex를 호출하기 전에 명확한 오류로 중단한다. `guardrailDocs`는 문서 내용이 아니라 경로 선택 입력이다.
 
+## Task worktree 운영
+
+`autopilot.py`는 primary checkout에서 branch를 전환하거나 phase 파일을
+commit하지 않는다. base는 `fetch`로만 동기화하고, 각 task의 구현·검증·review·PR
+준비는 `.codex-worktrees/<repository-name>/` 아래의 Harness 소유 worktree에서
+수행한다. 경로를 고정해야 하면 `--worktree-root`를 사용한다.
+
+```powershell
+python scripts/autopilot.py <phase-name> --base develop --worktree-root <absolute-path>
+python scripts/worktree.py list
+python scripts/worktree.py resume <task-id>
+python scripts/worktree.py cleanup <task-id> --expected-head-sha <sha>
+```
+
+`scripts/worktree.py`는 Git administrative directory의 marker를 읽어 task,
+branch, 절대 path, base ref/SHA, owner와 상태를 확인한다. marker가 없는 기존
+path/branch, owner가 다른 marker, stale administrative entry와 dirty/ignored
+worktree는 자동 정리하지 않고 진단과 함께 보존한다. 성공적으로 merge된
+Harness 소유 worktree만 clean/head/active-entry gate 뒤에 force 없이 정리한다.
+상태 전이와 v1/v2 migration 경계는 [`docs/WORKTREE_LIFECYCLE.md`](WORKTREE_LIFECYCLE.md)를
+기준으로 한다.
+
 `scope-rules.json` rule schema:
 
 ```json

--- a/docs/SCOPE_CHANGE_CHECKLIST.md
+++ b/docs/SCOPE_CHANGE_CHECKLIST.md
@@ -43,6 +43,7 @@
 | `docs/ADR.md`, `docs/adr/{NNNN}-*.md` | 새 결정 ADR 추가, 인덱스 연결, 이전 ADR과의 관계 |
 | `docs/COMMANDS.md` | 활성 명령, 새 검증 명령, 폐기된 명령 제거 |
 | `docs/TASK_SCHEMA.md` | phase index v1/v2 필드, status, validation과 migration 경계 |
+| `docs/WORKTREE_LIFECYCLE.md` | task worktree 상태, 소유권, marker, 정리와 resume 경계 |
 | `AGENTS.md` | 목표/기술 스택 문구, CRITICAL 규칙, 디렉터리 규칙이 새 범위와 충돌하지 않는지 |
 
 API 명세, DB 스키마, 화면 설계, 공유/배포 가이드 같은 프로젝트 전용 문서를
@@ -82,6 +83,7 @@ API 명세, DB 스키마, 화면 설계, 공유/배포 가이드 같은 프로�
 | `scripts/task_schema.py` | phase index schema, 정규화 또는 pre-Codex validation이 바뀔 때 |
 | `scripts/execute.py` | branch/commit/final 검증 같은 phase 실행 workflow가 바뀔 때 |
 | `scripts/autopilot.py` | PR 생성, 자체 리뷰, issue 기록, merge loop workflow가 바뀔 때 |
+| `scripts/worktree.py` | task worktree 생성·조회·재개·소유권·안전 정리 workflow가 바뀔 때 |
 | `scripts/tests/test_*.py` | 위 스크립트 동작을 바꾼 경우 |
 
 범위별 문서 검증 규칙은 `phases/{phase}/docs-checks.json`, 범위 금지 키워드는

--- a/docs/WORKTREE_LIFECYCLE.md
+++ b/docs/WORKTREE_LIFECYCLE.md
@@ -1,0 +1,119 @@
+# Task worktree lifecycle
+
+이 문서는 Harness가 task별 Git worktree를 만들고 재개하며 정리할 때의 운영
+계약이다. 기본 checkout은 사용자의 작업 공간으로 간주하고, Harness가 소유하지
+않은 branch·worktree·stale administrative entry는 자동으로 바꾸거나 삭제하지
+않는다.
+
+## 역할과 기본 경로
+
+- **primary checkout**: autopilot을 시작한 checkout이다. 현재 branch, 파일,
+  index와 사용자의 변경을 보존하며 branch switch, commit, stage를 하지 않는다.
+- **task worktree**: 한 task의 구현·인수 검증·read-only review·PR 준비가 일어나는
+  독립 checkout이다. autopilot은 동시성 1로 하나만 활성화한다.
+- 기본 task worktree root는 primary checkout의 부모 아래
+  `.codex-worktrees/<repository-name>/`이다. `--worktree-root`로 다른 절대 경로를
+  지정할 수 있지만 primary checkout 안쪽 경로는 사용하지 않는다.
+- marker는 working tree 파일이 아니라 Git worktree administrative directory의
+  `harness-worktree.json`에 저장한다. 따라서 marker가 task 변경에 섞이거나
+  primary checkout을 dirty하게 만들지 않는다.
+
+## Marker 최소 계약
+
+marker는 UTF-8 JSON이며 전체 prompt, credential, Codex thread 원문을 저장하지
+않는다.
+
+| 필드 | 의미 |
+| --- | --- |
+| `schemaVersion` | marker 형식 버전. 현재 `1` |
+| `owner` | 정확히 `codex-harness`여야 Harness 소유로 인정 |
+| `taskId` | phase 안에서 task를 재식별하는 안정적인 ID |
+| `phase` | 실행 중인 phase 이름 |
+| `branch` | task branch 이름 |
+| `worktreePath` | 정규화된 절대 worktree 경로 |
+| `baseRef` | 생성에 사용한 remote/base ref, 예: `origin/develop` |
+| `baseSha` | `baseRef`를 생성 시점에 해석한 전체 commit SHA |
+| `status` | lifecycle 상태 |
+| `headSha` | 마지막으로 확인한 task HEAD SHA(선택) |
+| `createdAt`, `updatedAt` | marker 기록 시각 |
+| `lastError`, `diagnostics` | 재개·수동 복구에 필요한 축약 진단(선택) |
+
+marker는 임시 파일에 먼저 기록한 뒤 같은 administrative directory 안에서
+atomic replace한다. 부분 JSON은 유효한 상태로 보지 않으며, 읽기 실패는 해당
+task를 보존한 채 진단한다.
+
+## 상태 전이
+
+```text
+created -> running -> implemented -> reviewing -> ready -> merged -> cleanup
+   |         |            |             |          |
+   +---------+------------+-------------+----------+--> error | blocked | interrupted
+                                                        ^
+                                                        |
+                                      error/blocked/interrupted --resume--> running
+```
+
+- `created`부터 `ready`까지는 같은 marker의 task만 갱신한다.
+- `error`, `blocked`, `interrupted`는 실패 원인과 진단을 기록하고 checkout과
+  branch를 남긴다. 재실행은 새 branch를 만들지 않고 marker의 동일 task/path/
+  branch/base를 검증한 뒤 `running`으로 재개한다.
+- `merged`는 PR merge 성공만 의미한다. `completed`라는 Codex 보고만으로는
+  정리할 수 없다.
+- 상태 갱신·base sync·PR merge는 autopilot의 repository lock 안에서 한 번에
+  하나씩 수행한다. `dependsOn`은 이 단계에서 scheduler로 해석하지 않는다.
+
+## 소유권과 재개 판정
+
+다음 네 값이 marker와 요청에 모두 일치해야 기존 task를 재개한다.
+
+1. `owner == codex-harness`
+2. `taskId`와 phase/branch가 일치
+3. 정규화한 `worktreePath`가 일치하고 managed root 아래에 있음
+4. `baseRef`와 `baseSha`가 일치하고 Git administrative entry가 그 경로와
+   branch를 가리킴
+
+marker가 없거나, owner가 다르거나, 이미 존재하는 branch/path가 다른 작업에
+속하면 `WorktreeConflict`로 중단한다. 기존 내용을 덮어쓰거나 `git checkout`으로
+사용자 branch를 이동하지 않는다. path는 존재하지만 marker가 없는 경우 비어
+있어 보여도 소유권을 추측하지 않는다.
+
+Git administrative entry만 남은 stale 상태도 자동 `git worktree prune` 대상이
+아니다. Harness 소유 marker와 실제 경로가 불일치하면 stale 진단을 보존하고
+사람이 entry와 파일을 확인한 뒤 복구한다.
+
+## 안전 정리 gate
+
+`safe_cleanup`은 다음 조건을 모두 확인한 Harness 소유 task에만 적용한다.
+
+- marker status가 `merged`이고 owner/task/path/branch가 일치한다.
+- path가 primary가 아니며 managed root 아래의 절대 경로다.
+- Git이 path를 해당 branch의 active worktree로 보고하고 administrative entry가
+  stale하지 않다.
+- `git status --porcelain --untracked-files=all --ignored`가 비어 있고, HEAD가
+  marker의 `headSha` 또는 호출자가 고정한 expected SHA와 같다.
+- `git worktree remove`가 force 없이 성공한다. local branch 삭제는 marker의
+  Harness 소유 branch에 대해서만 `git branch -d`로 시도하며, 실패하면 branch를
+  보존한다.
+
+어느 gate라도 실패하면 worktree·marker·진단을 보존한다. `--force`, `reset --hard`,
+사용자 branch 삭제, 사용자 worktree 이동, 무차별 `prune`은 lifecycle 구현에서
+사용하지 않는다.
+
+## 운영 및 migration
+
+```powershell
+python scripts/worktree.py list
+python scripts/worktree.py resume <task-id>
+python scripts/worktree.py cleanup <task-id> --expected-head-sha <sha>
+python scripts/autopilot.py <phase-name> --base develop --max-review-fixes 2
+```
+
+`list`는 active/stale marker를 읽기만 한다. `resume`은 동일 marker의 소유권과
+경로를 검증해 재개 정보를 출력한다. `cleanup`은 merge와 expected SHA를 사람이
+확인한 뒤에도 위 gate를 다시 통과해야 한다.
+
+기존 phase/index의 v1 `steps[]`와 v2 `tasks[]`는 그대로 유지한다. worktree
+marker는 phase index migration이 아니며, v1을 v2로 바꾸거나 기존 branch를
+Harness 소유로 소급하지 않는다. 인스턴스에 이 계약을 적용할 때는
+`guides/UPGRADE.md`의 template-owned 파일 복사, marker가 없는 기존 작업 보존,
+doctor·unit test·CI 검증 순서를 따른다.

--- a/docs/adr/0004-isolated-task-worktrees.md
+++ b/docs/adr/0004-isolated-task-worktrees.md
@@ -1,0 +1,55 @@
+# ADR-0004: Isolated task worktree lifecycle
+
+## Status
+
+Accepted
+
+## Context
+
+`execute.py`와 `autopilot.py`의 기존 경로는 현재 checkout에서 branch를 전환하고
+base를 pull한 뒤 구현·검증·review를 수행했다. 사용자의 dirty worktree를 보호하려면
+task 변경을 별도 checkout에서 실행하고, 중단 후에도 같은 task를 재식별할 수 있어야
+한다. 동시에 v1/v2 phase index의 list-order 직렬 실행과 기존 PR gate는 유지해야
+한다.
+
+## Decision
+
+1. `scripts/worktree.py`에 task worktree의 생성·조회·재개·안전 정리를 분리한다.
+2. Harness는 Git administrative directory의 `harness-worktree.json` marker에
+   `owner`, `taskId`, phase, branch, 절대 path, `baseRef`, `baseSha`와 lifecycle
+   진단을 기록한다. marker는 atomic replace하며 working tree에는 파일을 만들지
+   않는다.
+3. 기존 marker의 owner, task/path/branch/base가 모두 일치할 때만 재개한다. 이미
+   존재하는 사용자 branch/path, marker 없는 directory, owner 불일치, stale
+   administrative entry는 보존하고 명확한 충돌 또는 stale 오류로 중단한다.
+4. autopilot은 primary에서 branch switch/commit/stage하지 않는다. base는
+   `fetch`와 remote ref/SHA 확인으로만 동기화하고, 구현·acceptance·review·PR
+   준비는 task worktree에서 수행한다.
+5. 기존 `.codex/autopilot.lock`을 repository-wide concurrency 1 gate로 유지하며,
+   base sync와 PR merge를 같은 직렬 critical section에서 수행한다. v1 `steps[]`와
+   v2 `tasks[]`의 배열 순서 및 `dependsOn` reference-only 의미는 바꾸지 않는다.
+6. PR merge 후 `merged` marker, Harness owner, clean status, expected HEAD, active
+   administrative entry와 managed path를 모두 재검증한 경우에만 force 없는
+   `git worktree remove`와 Harness 소유 branch의 non-force `git branch -d`를
+   시도한다. 실패·blocked·중단은 marker와 checkout을 남긴다.
+
+## Consequences
+
+- primary checkout의 현재 branch와 변경사항을 보존하면서 task 단위 isolation과
+  resume 정보를 얻는다.
+- stale marker와 실패 checkout이 자동으로 사라지지 않아 수동 복구가 필요할 수
+  있지만, 사용자 작업을 잃지 않고 원인을 재현할 수 있다.
+- 별도 SDK, telemetry, native review adapter, DAG scheduler, ready-set 계산과
+  bounded concurrency는 이 결정에 포함하지 않는다. 후속 Issue가 별도 결정한다.
+- marker는 Git commit에 포함되지 않으므로 업그레이드 시 기존 phase/index와
+  프로젝트 소유 branch를 자동 migration하지 않는다.
+
+## 검증
+
+- 실제 임시 bare/working repository를 사용해 create/list/resume/cleanup과 branch
+  및 worktree isolation을 확인한다.
+- Windows 경로, 잠금 파일, 긴 경로, stale administrative entry, 기존 branch/path,
+  비정상 종료 후 재실행을 fixture로 검증한다.
+- execute/autopilot unit test에서 primary의 branch switch/commit/stage가 없고,
+  v1/v2 task가 같은 list-order로 한 번에 하나씩 task worktree에서 실행되는지
+  확인한다.

--- a/guides/CONFIGURATION.md
+++ b/guides/CONFIGURATION.md
@@ -141,3 +141,21 @@ phase별 `phases/<phase>/scope-rules.json`은 `extraForbidden`으로 금지 규�
 
 - ADR은 `docs/adr/0001-title.md` 형식으로 기록합니다.
 - `docs/ADR.md`는 ADR 인덱스와 운영 규칙만 유지합니다.
+
+## Task worktree
+
+격리 실행을 사용하는 autopilot은 primary checkout의 branch와 파일을 보존하고,
+기본적으로 primary 부모의 `.codex-worktrees/<repository-name>/`에 task worktree를
+만듭니다. 경로를 별도로 관리해야 하는 환경에서는 다음처럼 절대 경로를 지정합니다.
+
+```bash
+python scripts/autopilot.py <phase-name> --base develop --worktree-root <absolute-path>
+```
+
+task marker는 Git administrative directory에만 저장되며 `owner`가
+`codex-harness`인 경우에만 Harness 상태로 인정합니다. `scripts/worktree.py list`
+와 `resume`은 읽기 및 소유권 검증 중심이고, 사용자 path/branch와 stale entry를
+자동 prune하지 않습니다. merge 후 성공·clean·HEAD·active-entry gate가 통과한
+Harness 소유 worktree만 `cleanup` 대상입니다. 상세 상태 전이는
+[`docs/WORKTREE_LIFECYCLE.md`](../docs/WORKTREE_LIFECYCLE.md)와 ADR-0004를
+참조합니다.

--- a/guides/UPGRADE.md
+++ b/guides/UPGRADE.md
@@ -19,7 +19,7 @@
 
 | 단위 | 소유 | 업그레이드 시 |
 | --- | --- | --- |
-| `scripts/` (테스트 포함) | 템플릿 | 통째로 덮어쓰기 |
+| `scripts/` (테스트 포함, `worktree.py` 포함) | 템플릿 | 통째로 덮어쓰기 |
 | `.agents/skills/harness/`, `.agents/skills/review/` | 템플릿 공통 스킬 | 각 디렉터리만 통째로 덮어쓰기 |
 | `.githooks/`, `.codex/hooks/`, `.codex/hooks.json`, `.codex/config.toml`, `.gitattributes` | 템플릿 | 통째로 덮어쓰기 |
 | `guides/PROMPTS.md`, `guides/CONFIGURATION.md`, `guides/UPGRADE.md` | 템플릿 | 통째로 덮어쓰기 |
@@ -93,6 +93,27 @@ Harness 업그레이드는 phase index를 자동으로 v1에서 v2로 변환하�
 읽기 중 생성되는 v2의 `step`/`name` alias는 메모리 값이며 JSON에 저장되지
 않습니다. `dependsOn`은 현재 직렬 실행 순서를 바꾸지 않고, DAG scheduler·cycle
 처리·parallelism은 후속 기능으로 남겨 둡니다.
+
+## task worktree migration
+
+`scripts/worktree.py`와 `docs/WORKTREE_LIFECYCLE.md`는 새 Harness의 실행 계약이다.
+업그레이드 시 기존 phase/index, 사용자 branch와 worktree를 자동으로 Harness
+소유로 바꾸지 않는다. marker가 없는 기존 path/branch는 먼저 사람이 소유권을
+확인하고, 필요한 경우 새 managed root에서 task를 시작한다.
+
+1. 현재 작업의 `git worktree list --porcelain`, branch, dirty/ignored 파일을
+   보존하고 `python scripts/worktree.py list`로 marker/stale 상태를 확인한다.
+2. 템플릿 소유 `scripts/`를 dry-run으로 교체한 뒤 `doctor.py --instance`, 전체
+   unit test와 `git diff --check`를 실행한다.
+3. 실패·blocked·중단 marker는 삭제하지 말고 같은 `taskId`로 resume한다. base가
+   바뀌었거나 marker/administrative entry가 불일치하면 수동 reconcile을 먼저
+   완료한다.
+4. merge되지 않은 worktree는 cleanup하지 않는다. merge된 Harness 소유 task도
+   `docs/WORKTREE_LIFECYCLE.md`의 clean/head/owner gate를 다시 통과한 뒤에만
+   force 없는 정리를 수행한다.
+
+`git reset --hard`, force push, 사용자 branch 삭제, 사용자 worktree 이동과 무차별
+`git worktree prune`은 migration 절차에 포함되지 않는다.
 
 ## 템플릿 repo에서 버전 올리기
 

--- a/phases/0-example-v2/README.md
+++ b/phases/0-example-v2/README.md
@@ -9,12 +9,16 @@
 - `index.json`의 `tasks[]`에 결과 목표, 의존성, Issue와 위험도 메타데이터를
   기록한다.
 - 현재 Harness는 배열 순서를 그대로 따라 한 번에 하나의 task를 실행한다.
+- autopilot은 각 task를 독립 Harness worktree에서 배열 순서대로 실행하고,
+  primary checkout은 전환하지 않는다.
 
 ## 제외 범위
 
 - `dependsOn`을 이용한 DAG 스케줄링, ready set 계산, 병렬 실행은 이 예시에
   포함하지 않는다.
 - 기존 phase 파일을 v2로 자동 변환하지 않는다.
+- marker가 없는 사용자 worktree/branch와 stale administrative entry를 자동
+  삭제하거나 prune하지 않는다.
 
 ## Steps
 
@@ -27,6 +31,7 @@
 
 - 두 task가 선언된 배열 순서대로 실행된다.
 - v2 필수 필드와 dependency reference가 schema validator를 통과한다.
+- 실패 task의 worktree marker가 재개 정보를 보존한다.
 
 ## 검증 명령
 

--- a/phases/0-example/README.md
+++ b/phases/0-example/README.md
@@ -34,6 +34,13 @@
 - 현재 step이 미래 step 범위를 선행 구현하면 blocker로 본다.
 - 리뷰 실패는 같은 PR 브랜치에서 수정하고 `issues/0-example/issue-N.md`에 기록한다.
 
+## Worktree 실행
+
+autopilot은 각 step을 `codex/{phase}-step{N}-{name}` branch의 독립 Harness
+worktree에서 구현·검증·review한다. primary checkout은 전환하지 않으며, 실패한
+step worktree는 재개를 위해 보존한다. 상세 marker와 cleanup gate는
+[`docs/WORKTREE_LIFECYCLE.md`](../../docs/WORKTREE_LIFECYCLE.md)를 따른다.
+
 ## 완료 기준
 
 - 메모 추가/목록 명령이 동작하고 모든 step의 인수 기준이 통과한다.

--- a/phases/harness-v2-modernization/docs-checks.json
+++ b/phases/harness-v2-modernization/docs-checks.json
@@ -49,6 +49,16 @@
       "name": "task migration opt-in boundary",
       "paths": ["docs/TASK_SCHEMA.md"],
       "pattern": "자동 migration은 하지 않는다"
+    },
+    {
+      "name": "isolated worktree marker contract",
+      "paths": ["docs/WORKTREE_LIFECYCLE.md"],
+      "pattern": "owner.*codex-harness"
+    },
+    {
+      "name": "safe cleanup ownership gate",
+      "paths": ["docs/WORKTREE_LIFECYCLE.md"],
+      "pattern": "status가 `merged`이고 owner/task/path/branch가 일치"
     }
   ],
   "finalRequired": [],

--- a/phases/harness-v2-modernization/index.json
+++ b/phases/harness-v2-modernization/index.json
@@ -30,7 +30,13 @@
       "completed_at": "2026-09-04T19:47:12+0900",
       "summary": "outcome task v2 schema와 shared validation을 추가하고 v1 steps 실행·저장 형식과 serial list-order를 보존했다."
     },
-    { "step": 4, "name": "isolated-worktree", "status": "pending" },
+    {
+      "step": 4,
+      "name": "isolated-worktree",
+      "status": "completed",
+      "completed_at": "2026-09-04T21:51:08+0900",
+      "summary": "task별 owner marker와 pinned base SHA worktree lifecycle을 도입하고 primary 불변·직렬 autopilot·실패 보존·safe cleanup 및 Windows/stale 격리 검증을 추가했다."
+    },
     { "step": 5, "name": "sdk-spike", "status": "pending" },
     { "step": 6, "name": "runner-adapter", "status": "pending" },
     { "step": 7, "name": "resumable-telemetry", "status": "pending" },

--- a/phases/harness-v2-modernization/step4.md
+++ b/phases/harness-v2-modernization/step4.md
@@ -4,6 +4,9 @@
 
 - `/phases/harness-v2-modernization/README.md`
 - `/phases/harness-v2-modernization/COMPATIBILITY.md`
+- `/docs/ARCHITECTURE.md`
+- `/docs/WORKTREE_LIFECYCLE.md`
+- `/docs/ADR.md`
 - `/docs/adr/0001-step-pr-workflow.md`
 - `/scripts/execute.py`
 - `/scripts/autopilot.py`
@@ -12,11 +15,16 @@
 
 ## 작업
 
+- 구현 전에 `docs/WORKTREE_LIFECYCLE.md`와 ADR-0004에 상태 전이, marker 최소
+  필드, 소유권 판정, 실패 보존·재개, safe cleanup gate를 문서화하고 테스트
+  검증 방법을 고정한다.
 - task별 branch, worktree, owner와 lifecycle을 별도 모듈로 관리한다.
 - primary checkout의 branch를 전환하지 않고 동시성 1로 구현·검증·리뷰한다.
 - 성공 task만 안전하게 정리하고 실패 또는 blocked task는 재개할 수 있도록
   보존한다. base sync, PR merge와 state 갱신은 직렬화한다.
 - Windows path와 stale worktree를 포함한 테스트를 추가한다.
+- v1 `steps[]`와 v2 `tasks[]`가 같은 list-order 직렬 의미를 유지하고, task 간
+  변경이 실제 checkout 사이에서 격리되는 통합 테스트를 추가한다.
 
 ## 인수 기준
 
@@ -37,5 +45,7 @@ git diff --check
 
 - 복수 task를 동시에 실행하지 마라. 이유: bounded concurrency는 Step 9 범위다.
 - 사용자 worktree 또는 branch를 자동 삭제하지 마라. 이유: 소유권이 불명확하다.
+- stale administrative entry를 무차별 prune하지 마라. 이유: 다른 checkout의
+  보존 가능한 작업을 잃을 수 있다.
 - `git reset --hard`나 force push를 사용하지 마라. 이유: 복구 불가능한 변경을 막는다.
 - 기존 테스트를 깨뜨리지 마라.

--- a/scripts/autopilot.py
+++ b/scripts/autopilot.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import guard
 import task_schema
+import worktree
 from codex_common import (
     ALLOWED_CODEX_EFFORTS,
     CODEX_ENV_CONFIG,
@@ -43,6 +44,7 @@ NO_CHECKS_GRACE_SECONDS = 60
 NO_CHECKS_POLL_SECONDS = 15
 SCOPE_RULES_FILENAME = "scope-rules.json"
 LOCK_RELATIVE_PATH = Path(".codex") / "autopilot.lock"
+MAX_CONCURRENT_TASKS = 1
 REVIEW_OUTPUT_SCHEMA = {
     "type": "object",
     "properties": {
@@ -183,6 +185,7 @@ class AutopilotRunner:
         allow_no_checks: bool = False,
         skip_base_checks: bool = False,
         root: Path = ROOT,
+        worktree_root: Path | None = None,
     ):
         self.phase = phase
         self.base = base
@@ -196,7 +199,18 @@ class AutopilotRunner:
         self.max_steps = max_steps
         self.allow_no_checks = allow_no_checks
         self.skip_base_checks = skip_base_checks
-        self.root = Path(root)
+        self.root = Path(root).resolve()
+        self.worktree_root = (
+            Path(worktree_root).resolve() if worktree_root is not None else None
+        )
+        self._lifecycle = worktree.WorktreeLifecycle(
+            self.root,
+            worktree_root=self.worktree_root,
+        )
+        self._base_ref: str | None = None
+        self._base_sha: str | None = None
+        self._active_handle: worktree.WorktreeHandle | None = None
+        self._active_worktree: Path | None = None
         self._scope_rules_cache: dict | None = None
         self._global_scope_rules_cache: dict | None = None
 
@@ -209,11 +223,12 @@ class AutopilotRunner:
         check: bool = True,
         timeout: int | None = None,
         input_text: str | None = None,
+        cwd: Path | None = None,
     ) -> subprocess.CompletedProcess:
         try:
             result = subprocess.run(
                 cmd,
-                cwd=self.root,
+                cwd=cwd or self.root,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
@@ -233,11 +248,12 @@ class AutopilotRunner:
         *,
         check: bool = True,
         timeout: int | None = None,
+        cwd: Path | None = None,
     ) -> subprocess.CompletedProcess:
         try:
             result = subprocess.run(
                 command,
-                cwd=self.root,
+                cwd=cwd or self.root,
                 shell=True,
                 capture_output=True,
                 text=True,
@@ -251,8 +267,34 @@ class AutopilotRunner:
             raise AutopilotError(self._shell_command_failure(command, result))
         return result
 
+    def _run_shell_in_context(
+        self,
+        command: str,
+        *,
+        check: bool = True,
+        timeout: int | None = None,
+    ) -> subprocess.CompletedProcess:
+        if self._active_worktree is None:
+            return self._run_shell(command, check=check, timeout=timeout)
+        return self._run_shell(
+            command,
+            check=check,
+            timeout=timeout,
+            cwd=self._active_worktree,
+        )
+
     def _git(self, *args: str, check: bool = True) -> subprocess.CompletedProcess:
         return self._run(["git", *args], check=check, timeout=DEFAULT_GIT_TIMEOUT)
+
+    def _git_at(
+        self,
+        cwd: Path | None,
+        *args: str,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess:
+        if cwd is None:
+            return self._git(*args, check=check)
+        return self._run(["git", *args], check=check, timeout=DEFAULT_GIT_TIMEOUT, cwd=cwd)
 
     def _gh(
         self, *args: str, check: bool = True, timeout: int = DEFAULT_GH_TIMEOUT
@@ -288,13 +330,134 @@ class AutopilotRunner:
                 return "\n".join(merged_prs) if merged_prs else f"No pending steps for {self.phase}."
 
             branch = self._step_branch(step)
-            self._run_step(branch, step)
-            pr_url = self._create_pr(branch, step)
-            self._review_and_fix_until_passed(pr_url, branch, step)
+            handle: worktree.WorktreeHandle | None = None
+            if self._uses_isolated_worktrees():
+                handle = self._task_worktree(step)
+                if handle.state.status in worktree.PRESERVED_STATUSES:
+                    self._active_handle = self._lifecycle.resume(handle.state.task_id)
+                else:
+                    self._active_handle = self._lifecycle.transition(handle, "running")
+                self._active_worktree = self._active_handle.path
+                handle = self._active_handle
 
-            self._mark_ready_and_merge(pr_url)
-            merged_prs.append(pr_url)
+            try:
+                # execute.py is invoked from the task worktree. In a test-only
+                # fake root without Git, the legacy two-argument call remains
+                # useful for exercising PR/review orchestration in isolation.
+                self._run_step(branch, step)
+                if handle is not None:
+                    handle = self._lifecycle.transition(
+                        handle,
+                        "implemented",
+                        head_sha=self._worktree_head(handle.path),
+                    )
+                    self._active_handle = handle
+
+                pr_url = self._create_pr(branch, step)
+                if handle is not None:
+                    handle = self._lifecycle.transition(handle, "reviewing")
+                    self._active_handle = handle
+                self._review_and_fix_until_passed(pr_url, branch, step)
+
+                if handle is not None:
+                    handle = self._lifecycle.transition(
+                        handle,
+                        "ready",
+                        head_sha=self._worktree_head(handle.path),
+                    )
+                    self._active_handle = handle
+                self._mark_ready_and_merge(pr_url)
+                merged_prs.append(pr_url)
+
+                if handle is not None:
+                    handle = self._lifecycle.transition(
+                        handle,
+                        "merged",
+                        head_sha=self._worktree_head(handle.path),
+                    )
+                    self._active_handle = handle
+                    cleanup = self._lifecycle.safe_cleanup(
+                        handle,
+                        expected_head_sha=handle.state.head_sha,
+                    )
+                    if cleanup.diagnostics:
+                        print(
+                            "WARNING: worktree는 정리했지만 local branch 정리에 진단이 남았습니다: "
+                            + " | ".join(cleanup.diagnostics),
+                            file=sys.stderr,
+                        )
+            except KeyboardInterrupt as exc:
+                if handle is not None:
+                    self._preserve_worktree_failure(handle, "interrupted", "사용자 중단")
+                raise
+            except (AutopilotError, worktree.WorktreeLifecycleError) as exc:
+                if handle is not None:
+                    status = "blocked" if getattr(exc, "blocked", False) else "error"
+                    self._preserve_worktree_failure(handle, status, str(exc))
+                if isinstance(exc, worktree.WorktreeLifecycleError):
+                    raise AutopilotError(str(exc)) from exc
+                raise
+            finally:
+                self._active_handle = None
+                self._active_worktree = None
+
             self._sync_base()
+
+    def _uses_isolated_worktrees(self) -> bool:
+        """실제 Git 실행에서만 isolation을 활성화한다.
+
+        Git 없는 단위 fixture는 precondition을 명시적으로 우회하므로 기존
+        orchestration 테스트를 유지할 수 있다. 실제 autopilot 경로는
+        ``_ensure_preconditions``가 Git 저장소를 먼저 검증한다.
+        """
+        return (self.root / ".git").exists()
+
+    def _task_worktree(self, step: dict) -> worktree.WorktreeHandle:
+        task_id = str(
+            step.get("id")
+            or f"{self.phase}:step{step['step']}:{step['name']}"
+        )
+        base_ref = self._base_ref or f"origin/{self.base}"
+        base_sha = self._base_sha
+        # A preserved task continues from the marker's immutable base pin even
+        # when the remote base advanced after a later operator action.
+        existing = next(
+            (record for record in self._lifecycle.list() if record.state.task_id == task_id),
+            None,
+        )
+        if existing is not None:
+            base_ref = existing.state.base_ref
+            base_sha = existing.state.base_sha
+        return self._lifecycle.create_or_resume(
+            task_id=task_id,
+            phase=self.phase,
+            branch=self._step_branch(step),
+            base_ref=base_ref,
+            base_sha=base_sha,
+        )
+
+    def _worktree_head(self, path: Path) -> str:
+        result = self._run(["git", "rev-parse", "HEAD"], cwd=path)
+        return result.stdout.strip()
+
+    def _preserve_worktree_failure(
+        self,
+        handle: worktree.WorktreeHandle,
+        status: str,
+        message: str,
+    ) -> None:
+        try:
+            self._lifecycle.transition(
+                handle,
+                status,
+                error=message,
+                diagnostics=[f"primary={self.root}", f"worktree={handle.path}"],
+            )
+        except worktree.WorktreeLifecycleError as transition_error:
+            print(
+                f"WARNING: worktree failure state 기록도 실패했습니다: {transition_error}",
+                file=sys.stderr,
+            )
 
     def _dry_run_summary(self) -> str:
         index = self._load_phase_index()
@@ -420,7 +583,32 @@ class AutopilotRunner:
     def _ensure_base_checks_pass(self):
         # base가 이미 깨져 있으면 첫 step PR의 리뷰 gate가 step 실패처럼 보이는
         # 오인을 만든다. 루프 시작 전에 base에서 같은 검증을 돌려 fail-fast 한다.
-        result = self._run_shell(FALLBACK_REVIEW_CHECK_COMMAND, check=False, timeout=CODEX_EXEC_TIMEOUT)
+        validation_path: Path | None = None
+        if self._base_ref and self._base_sha and self._uses_isolated_worktrees():
+            validation_path = self._lifecycle.create_validation_worktree(
+                base_ref=self._base_ref,
+                base_sha=self._base_sha,
+            )
+            try:
+                result = self._run_shell(
+                    FALLBACK_REVIEW_CHECK_COMMAND,
+                    check=False,
+                    timeout=CODEX_EXEC_TIMEOUT,
+                    cwd=validation_path,
+                )
+            finally:
+                try:
+                    self._lifecycle.remove_validation_worktree(validation_path)
+                except worktree.WorktreeLifecycleError as exc:
+                    raise AutopilotError(
+                        f"base validation worktree를 안전하게 정리하지 못했습니다. 보존된 path: {validation_path}; {exc}"
+                    ) from exc
+        else:
+            result = self._run_shell_in_context(
+                FALLBACK_REVIEW_CHECK_COMMAND,
+                check=False,
+                timeout=CODEX_EXEC_TIMEOUT,
+            )
         if result.returncode != 0:
             raise AutopilotError(
                 f"base 브랜치 `{self.base}`의 manual 검증이 이미 실패해서 자동 PR 루프를 시작하지 않습니다. "
@@ -430,32 +618,84 @@ class AutopilotRunner:
 
     def _sync_base(self):
         self._git("fetch", "origin", self.base)
-        self._git("checkout", self.base)
-        self._git("pull", "--ff-only", "origin", self.base)
+        ref = f"origin/{self.base}"
+        result = self._git(
+            "rev-parse",
+            "--verify",
+            f"refs/remotes/origin/{self.base}^{{commit}}",
+            check=False,
+        )
+        if result.returncode != 0:
+            if (self.root / ".git").exists():
+                raise AutopilotError(
+                    f"원격 base ref `{ref}`의 commit을 확인하지 못해 primary checkout을 건드리지 않고 중단합니다.\n"
+                    + self._command_failure(
+                        ["git", "rev-parse", "--verify", f"refs/remotes/origin/{self.base}^{{commit}}"],
+                        result,
+                    )
+                )
+            self._base_ref = None
+            self._base_sha = None
+            return
+        self._base_ref = ref
+        self._base_sha = result.stdout.strip() or None
 
-    def _phase_index_path(self) -> Path:
-        return self.root / "phases" / self.phase / "index.json"
+    def _phase_index_path(self, root: Path | None = None) -> Path:
+        return (root or self.root) / "phases" / self.phase / "index.json"
 
-    def _load_phase_index(self) -> task_schema.NormalizedPhaseIndex:
-        path = self._phase_index_path()
+    def _load_phase_index(self, root: Path | None = None) -> task_schema.NormalizedPhaseIndex:
+        path = self._phase_index_path(root)
         try:
-            return task_schema.load_phase_index(path, display_path=path.relative_to(self.root))
+            display_path = (
+                path.relative_to(root or self.root)
+                if (root or self.root) in path.parents or path == (root or self.root)
+                else path
+            )
+            return task_schema.load_phase_index(path, display_path=display_path)
         except task_schema.TaskSchemaError as exc:
             raise AutopilotError(str(exc)) from exc
 
     def _next_pending_step(self) -> dict | None:
-        index = self._load_phase_index()
+        index = self._load_base_phase_index()
         return next((s for s in index.get("steps", []) if s.get("status") == "pending"), None)
+
+    def _load_base_phase_index(self) -> task_schema.NormalizedPhaseIndex:
+        """primary checkout을 branch switch하지 않고 fetch한 base에서 읽는다."""
+        if self._base_ref and (self.root / ".git").exists():
+            relative = f"phases/{self.phase}/index.json"
+            result = self._git("show", f"{self._base_ref}:{relative}", check=False)
+            if result.returncode != 0:
+                raise AutopilotError(
+                    f"base ref `{self._base_ref}`에서 phase index를 읽지 못했습니다.\n"
+                    + self._command_failure(["git", "show", f"{self._base_ref}:{relative}"], result)
+                )
+            try:
+                payload = json.loads(result.stdout)
+                return task_schema.normalize_phase_index(payload, path=relative)
+            except (json.JSONDecodeError, task_schema.TaskSchemaError) as exc:
+                raise AutopilotError(f"base phase index 파싱 실패: {exc}") from exc
+        return self._load_phase_index()
 
     def _step_branch(self, step: dict) -> str:
         return f"codex/{self.phase}-step{step['step']}-{step['name']}"
 
     # --- step execution and PR ---
 
-    def _run_step(self, branch: str, step: dict):
+    def _run_step(
+        self,
+        branch: str,
+        step: dict,
+        worktree_path: Path | None = None,
+    ):
+        task_root = worktree_path or self._active_worktree
+        execute_script = (
+            str(task_root / "scripts" / "execute.py")
+            if task_root is not None
+            else "scripts/execute.py"
+        )
         cmd = [
             sys.executable,
-            "scripts/execute.py",
+            execute_script,
             self.phase,
             "--branch",
             branch,
@@ -469,7 +709,14 @@ class AutopilotRunner:
             cmd.append("--allow-xhigh")
         if self.unsafe:
             cmd.append("--unsafe")
-        self._run(cmd, timeout=CODEX_EXEC_TIMEOUT)
+        if task_root is None:
+            result = self._run(cmd, check=False, timeout=CODEX_EXEC_TIMEOUT)
+        else:
+            result = self._run(cmd, check=False, timeout=CODEX_EXEC_TIMEOUT, cwd=task_root)
+        if result.returncode != 0:
+            error = AutopilotError(self._command_failure(cmd, result))
+            error.blocked = result.returncode == 2
+            raise error
 
     def _create_pr(self, branch: str, step: dict) -> str:
         title = f"feat: {self.phase} {step['step']}단계 {step['name']} 구현"
@@ -490,9 +737,9 @@ class AutopilotRunner:
         return self._extract_url(result.stdout) or branch
 
     def _pr_body(self, branch: str, step: dict) -> str:
-        refreshed = self._step_from_index(step["step"]) or step
+        refreshed = self._step_from_index(step["step"], root=self._active_worktree) or step
         summary = refreshed.get("summary") or "step 실행 결과를 phase index에 기록했습니다."
-        task = self._step_task_summary(step)
+        task = self._step_task_summary(step, root=self._active_worktree)
         changed_files = self._changed_files()
         changed_section = "\n".join(f"- `{path}`" for path in changed_files[:12])
         if len(changed_files) > 12:
@@ -531,14 +778,14 @@ class AutopilotRunner:
     def _sentence_fragment(text: str) -> str:
         return text.strip().rstrip(".")
 
-    def _step_from_index(self, step_num: int) -> dict | None:
-        index = self._load_phase_index()
+    def _step_from_index(self, step_num: int, root: Path | None = None) -> dict | None:
+        index = self._load_phase_index(root=root)
         return next((s for s in index.get("steps", []) if s.get("step") == step_num), None)
 
-    def _step_task_summary(self, step: dict) -> str:
+    def _step_task_summary(self, step: dict, root: Path | None = None) -> str:
         if step.get("objective"):
             return str(step["objective"])
-        path = self.root / "phases" / self.phase / f"step{step['step']}.md"
+        path = (root or self._active_worktree or self.root) / "phases" / self.phase / f"step{step['step']}.md"
         if not path.exists():
             return step["name"]
         in_task = False
@@ -554,7 +801,13 @@ class AutopilotRunner:
         return step["name"]
 
     def _changed_files(self) -> list[str]:
-        result = self._git("diff", "--name-only", f"origin/{self.base}...HEAD", check=False)
+        result = self._git_at(
+            self._active_worktree,
+            "diff",
+            "--name-only",
+            f"{self._base_ref or f'origin/{self.base}'}...HEAD",
+            check=False,
+        )
         if result.returncode != 0:
             return []
         return [line for line in result.stdout.splitlines() if line.strip()]
@@ -564,7 +817,7 @@ class AutopilotRunner:
         if step_number is None:
             return (FALLBACK_REVIEW_CHECK_COMMAND,)
 
-        path = self.root / "phases" / self.phase / f"step{step_number}.md"
+        path = (self._active_worktree or self.root) / "phases" / self.phase / f"step{step_number}.md"
         return read_acceptance_commands(path) or (FALLBACK_REVIEW_CHECK_COMMAND,)
 
     def _review_check_commands(self, step: dict | None = None) -> tuple[str, ...]:
@@ -580,12 +833,41 @@ class AutopilotRunner:
     def _run_final_gate(self):
         commands = (
             f"{shell_quote(sys.executable)} scripts/checks.py --stage final",
-            f"git diff --check origin/{self.base}...HEAD",
+            f"git diff --check {self._base_ref or f'origin/{self.base}'}...HEAD",
         )
-        for command in commands:
-            result = self._run_shell(command, check=False, timeout=CODEX_EXEC_TIMEOUT)
-            if result.returncode != 0:
-                raise AutopilotError(self._shell_command_failure(command, result))
+        validation_path: Path | None = None
+        try:
+            if self._base_ref and self._base_sha and self._uses_isolated_worktrees():
+                validation_path = self._lifecycle.create_validation_worktree(
+                    base_ref=self._base_ref,
+                    base_sha=self._base_sha,
+                )
+                for command in commands:
+                    result = self._run_shell(
+                        command,
+                        check=False,
+                        timeout=CODEX_EXEC_TIMEOUT,
+                        cwd=validation_path,
+                    )
+                    if result.returncode != 0:
+                        raise AutopilotError(self._shell_command_failure(command, result))
+            else:
+                for command in commands:
+                    result = self._run_shell_in_context(
+                        command,
+                        check=False,
+                        timeout=CODEX_EXEC_TIMEOUT,
+                    )
+                    if result.returncode != 0:
+                        raise AutopilotError(self._shell_command_failure(command, result))
+        finally:
+            if validation_path is not None:
+                try:
+                    self._lifecycle.remove_validation_worktree(validation_path)
+                except worktree.WorktreeLifecycleError as exc:
+                    raise AutopilotError(
+                        f"final validation worktree를 안전하게 정리하지 못했습니다. 보존된 path: {validation_path}; {exc}"
+                    ) from exc
 
     def _mark_ready_and_merge(self, pr_url: str):
         self._gh("pr", "ready", pr_url)
@@ -649,7 +931,7 @@ class AutopilotRunner:
                 checks_passed = False
                 findings.append(f"인수 기준 명령이 위험 명령 정책에 차단되었습니다: {danger}")
                 continue
-            result = self._run_shell(command, check=False, timeout=CODEX_EXEC_TIMEOUT)
+            result = self._run_shell_in_context(command, check=False, timeout=CODEX_EXEC_TIMEOUT)
             if result.returncode != 0:
                 if self._is_diff_check_command(command):
                     diff_passed = False
@@ -695,8 +977,9 @@ class AutopilotRunner:
     # --- scope rules ---
 
     def _scan_scope_diff(self, step: dict | None = None) -> list[str]:
-        diff_cmd = ["git", "diff", "--unified=0", f"origin/{self.base}...HEAD"]
-        result = self._git(*diff_cmd[1:], check=False)
+        base_ref = self._base_ref or f"origin/{self.base}"
+        diff_cmd = ["git", "diff", "--unified=0", f"{base_ref}...HEAD"]
+        result = self._git_at(self._active_worktree, *diff_cmd[1:], check=False)
         if result.returncode != 0:
             # diff 실패를 빈 finding으로 돌리면 scope gate가 검사 없이 통과한다.
             # 실패 자체를 finding으로 보고해 gate를 막는다.
@@ -722,7 +1005,7 @@ class AutopilotRunner:
                 line = raw[1:]
                 active_line = line_no
                 line_no += 1
-                if self._line_in_safe_section(current_file, active_line):
+                if self._line_in_safe_section(current_file, active_line, root=self._active_worktree):
                     continue
                 for message in self._forbidden_messages(line):
                     if self._is_allowed_scope_message(message, line, step):
@@ -775,7 +1058,10 @@ class AutopilotRunner:
         """phases/<phase>/scope-rules.json — phase별 금지/허용 규칙."""
         if self._scope_rules_cache is None:
             self._scope_rules_cache = self._load_scope_rules_file(
-                self.root / "phases" / self.phase / SCOPE_RULES_FILENAME
+                (self._active_worktree or self.root)
+                / "phases"
+                / self.phase
+                / SCOPE_RULES_FILENAME
             )
         return self._scope_rules_cache
 
@@ -783,7 +1069,7 @@ class AutopilotRunner:
         """.codex/scope-rules.json — 모든 phase에 적용되는 금지 규칙."""
         if self._global_scope_rules_cache is None:
             self._global_scope_rules_cache = self._load_scope_rules_file(
-                self.root / ".codex" / SCOPE_RULES_FILENAME
+                (self._active_worktree or self.root) / ".codex" / SCOPE_RULES_FILENAME
             )
         return self._global_scope_rules_cache
 
@@ -850,8 +1136,14 @@ class AutopilotRunner:
             or self.STEP_OUTPUT_RE.match(normalized) is not None
         )
 
-    def _line_in_safe_section(self, path: str, line_no: int) -> bool:
-        target = self.root / path
+    def _line_in_safe_section(
+        self,
+        path: str,
+        line_no: int,
+        *,
+        root: Path | None = None,
+    ) -> bool:
+        target = (root or self._active_worktree or self.root) / path
         if not target.exists() or line_no <= 0:
             return False
         try:
@@ -885,7 +1177,21 @@ class AutopilotRunner:
                 str(last_message_path),
                 "-",
             ]
-            result = self._run(cmd, check=False, timeout=CODEX_EXEC_TIMEOUT, input_text=prompt)
+            if self._active_worktree is None:
+                result = self._run(
+                    cmd,
+                    check=False,
+                    timeout=CODEX_EXEC_TIMEOUT,
+                    input_text=prompt,
+                )
+            else:
+                result = self._run(
+                    cmd,
+                    check=False,
+                    timeout=CODEX_EXEC_TIMEOUT,
+                    input_text=prompt,
+                    cwd=self._active_worktree,
+                )
             last_message = (
                 last_message_path.read_text(encoding="utf-8")
                 if last_message_path.exists()
@@ -942,7 +1248,13 @@ class AutopilotRunner:
             return Path(file.name)
 
     def _worktree_status(self) -> str:
-        result = self._git("status", "--short", "--untracked-files=all", check=False)
+        result = self._git_at(
+            self._active_worktree,
+            "status",
+            "--short",
+            "--untracked-files=all",
+            check=False,
+        )
         if result.returncode != 0:
             return f"<git status failed: {self._compact_output(result.stderr.strip())}>"
         return result.stdout.strip()
@@ -1087,7 +1399,7 @@ class AutopilotRunner:
         number = self._next_issue_number()
         title = f"{self.phase} step {step['step']} 자동 리뷰 실패 {number}"
         body = self._issue_body(pr_url, review, step)
-        issue_dir = self.root / "issues" / self.phase
+        issue_dir = (self._active_worktree or self.root) / "issues" / self.phase
         issue_dir.mkdir(parents=True, exist_ok=True)
         local_path = issue_dir / f"issue-{number}.md"
         local_path.write_text(f"# Issue {number}: {title}\n\n{body}", encoding="utf-8")
@@ -1120,19 +1432,20 @@ class AutopilotRunner:
         self._commit_issue_record(issue.local_path, step, message_suffix="자동 리뷰 해결 기록")
 
     def _commit_issue_record(self, local_path: Path, step: dict, *, message_suffix: str = "자동 리뷰 실패 기록"):
+        git_root = self._active_worktree or self.root
         try:
-            rel_path = local_path.relative_to(self.root)
+            rel_path = local_path.relative_to(git_root)
         except ValueError:
             rel_path = local_path
 
-        if self._git("add", "--", str(rel_path), check=False).returncode != 0:
+        if self._git_at(git_root, "add", "--", str(rel_path), check=False).returncode != 0:
             return
-        if self._git("diff", "--cached", "--quiet", check=False).returncode == 0:
+        if self._git_at(git_root, "diff", "--cached", "--quiet", check=False).returncode == 0:
             return
 
         message = f"chore: {self.phase} {step['step']}단계 {message_suffix}"
-        if self._git("commit", "-m", message, check=False).returncode == 0:
-            self._git("push", check=False)
+        if self._git_at(git_root, "commit", "-m", message, check=False).returncode == 0:
+            self._git_at(git_root, "push", check=False)
 
     def _invoke_codex_fix(
         self,
@@ -1163,23 +1476,32 @@ class AutopilotRunner:
         cmd = codex_base_cmd(self.fix_effort)
         # 프롬프트는 argv 대신 stdin으로 전달해서 ARG_MAX 한계를 피한다.
         cmd.append("-")
-        self._run(cmd, timeout=CODEX_EXEC_TIMEOUT, input_text=prompt)
+        if self._active_worktree is None:
+            self._run(cmd, timeout=CODEX_EXEC_TIMEOUT, input_text=prompt)
+        else:
+            self._run(
+                cmd,
+                timeout=CODEX_EXEC_TIMEOUT,
+                input_text=prompt,
+                cwd=self._active_worktree,
+            )
 
     def _commit_dirty_fix(self, step: dict):
-        status = self._git("status", "--short", "--untracked-files=all").stdout.strip()
+        git_root = self._active_worktree or self.root
+        status = self._git_at(git_root, "status", "--short", "--untracked-files=all").stdout.strip()
         if not status:
             return
-        self._git("add", "-A")
-        if self._git("diff", "--cached", "--quiet", check=False).returncode == 0:
+        self._git_at(git_root, "add", "-A")
+        if self._git_at(git_root, "diff", "--cached", "--quiet", check=False).returncode == 0:
             return
         msg = f"fix: {self.phase} {step['step']}단계 리뷰 이슈 수정"
-        self._git("commit", "-m", msg)
+        self._git_at(git_root, "commit", "-m", msg)
 
     def _push_branch(self, branch: str):
-        self._git("push", "-u", "origin", branch)
+        self._git_at(self._active_worktree, "push", "-u", "origin", branch)
 
     def _next_issue_number(self) -> int:
-        issue_dir = self.root / "issues" / self.phase
+        issue_dir = (self._active_worktree or self.root) / "issues" / self.phase
         if not issue_dir.is_dir():
             return 1
         numbers: list[int] = []
@@ -1242,6 +1564,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Skip the base-branch manual check verification before starting the PR loop",
     )
     parser.add_argument(
+        "--worktree-root",
+        type=Path,
+        help="Managed root for Harness task worktrees (default: sibling .codex-worktrees/<repo>)",
+    )
+    parser.add_argument(
         "--step-effort",
         choices=ALLOWED_CODEX_EFFORTS,
         default=DEFAULT_STEP_EFFORT,
@@ -1289,6 +1616,7 @@ def main(argv: list[str] | None = None) -> int:
             max_steps=args.max_steps,
             allow_no_checks=args.allow_no_checks,
             skip_base_checks=args.skip_base_checks,
+            worktree_root=args.worktree_root,
         ).run()
     except AutopilotError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/scripts/codex_common.py
+++ b/scripts/codex_common.py
@@ -14,7 +14,7 @@ from pathlib import Path
 # .codex/project-profile.json `templateVersion`에 기록하고, doctor가 둘을
 # 비교해 "harness 파일과 동기화 기록이 어긋난 상태"를 잡는다.
 # 업그레이드 절차는 템플릿 guides/UPGRADE.md를 따른다.
-TEMPLATE_VERSION = "2026.09.04.1"
+TEMPLATE_VERSION = "2026.09.04.2"
 
 ALLOWED_CODEX_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
 CODEX_EXEC_TIMEOUT = 1800

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -43,6 +43,7 @@ REQUIRED_FILES = [
     "scripts/doctor.py",
     "scripts/guard.py",
     "scripts/task_schema.py",
+    "scripts/worktree.py",
     "scripts/upgrade.py",
     "docs/TASK_SCHEMA.md",
 ]
@@ -58,6 +59,13 @@ PLACEHOLDER_PATTERN = re.compile(r"<[^>\n]+>|TODO|TBD")
 MODES = ("template", "instance")
 LEGACY_HOOK_MARKERS = ("/bin/bash", "/usr/bin/python3", "$(git rev-parse")
 PYTHON_ONLY_HOOK_MARKER = "python .codex/hooks/tdd-guard.py"
+WORKTREE_CONTRACT_MARKERS = (
+    "harness-worktree.json",
+    "owner",
+    "codex-harness",
+    "safe_cleanup",
+    "primary checkout",
+)
 # phase 파일 형식의 살아있는 예시. SKILL.md 산문과 달리 스키마가 깨지면
 # template 모드 doctor(및 CI)가 잡아내므로, 형식 변경 시 예시도 함께 갱신된다.
 EXAMPLE_PHASE_DIR = "phases/0-example"
@@ -163,6 +171,13 @@ def _template_contract_issues(root: Path) -> list[str]:
     for rel in TEMPLATE_REQUIRED_FILES:
         if not (root / rel).exists():
             issues.append(f"{rel} is missing.")
+
+    lifecycle_doc = _read_text(root, "docs/WORKTREE_LIFECYCLE.md")
+    for marker in WORKTREE_CONTRACT_MARKERS:
+        if marker not in lifecycle_doc:
+            issues.append(
+                f"docs/WORKTREE_LIFECYCLE.md must document the worktree lifecycle marker `{marker}`."
+            )
 
     hooks_json = _read_text(root, ".codex/hooks.json")
     if "python3 .codex/hooks/tdd-guard.py" not in hooks_json:

--- a/scripts/execute.py
+++ b/scripts/execute.py
@@ -215,17 +215,12 @@ class StepExecutor:
 
         if r.stdout.strip() == branch:
             return
-
-        r = self._run_git("rev-parse", "--verify", f"refs/heads/{branch}")
-        r = self._run_git("checkout", branch) if r.returncode == 0 else self._run_git("checkout", "-b", branch)
-
-        if r.returncode != 0:
-            print(f"  ERROR: 브랜치 '{branch}' checkout 실패.")
-            print(f"  {r.stderr.strip()}")
-            print("  Hint: 변경사항을 stash하거나 commit한 후 다시 시도하세요.")
-            sys.exit(1)
-
-        print(f"  Branch: {branch}")
+        print(
+            "  ERROR: execute.py는 현재 checkout의 branch를 바꾸지 않습니다.\n"
+            f"  요청 branch: {branch}\n"
+            "  Harness autopilot이 만든 task worktree에서 다시 실행하세요."
+        )
+        sys.exit(1)
 
     def _commit_step(self, step_num: int, step_name: str):
         output_rel = f"phases/{self._phase_dir_name}/step{step_num}-output.json"

--- a/scripts/tests/test_autopilot.py
+++ b/scripts/tests/test_autopilot.py
@@ -123,6 +123,42 @@ def test_preconditions_reject_invalid_v2_before_github_or_codex(runner, tmp_repo
         runner._ensure_preconditions()
 
 
+def test_sync_base_fetches_remote_ref_without_switching_primary_branch(runner):
+    calls = []
+
+    def fake_git(*args, check=True):
+        calls.append(args)
+        if args[:2] == ("rev-parse", "--verify"):
+            return cp(stdout="a" * 40 + "\n")
+        return cp()
+
+    runner._git = fake_git
+
+    runner._sync_base()
+
+    assert ("fetch", "origin", "main") in calls
+    assert not any(args and args[0] in {"checkout", "switch", "pull"} for args in calls)
+    assert runner._base_sha == "a" * 40
+    assert runner._base_ref == "origin/main"
+
+
+def test_run_step_uses_task_worktree_as_cwd(runner, tmp_repo):
+    seen = {}
+    worktree_path = tmp_repo / "isolated"
+    worktree_path.mkdir()
+
+    def fake_run(cmd, check=True, timeout=None, input_text=None, cwd=None):
+        seen.update(cmd=cmd, cwd=cwd, timeout=timeout)
+        return cp()
+
+    runner._run = fake_run
+    runner._run_step("codex/task", {"step": 0, "name": "project-scaffold"}, worktree_path)
+
+    assert seen["cwd"] == worktree_path
+    assert seen["cmd"][0] == sys.executable
+    assert seen["cmd"][1] == str(worktree_path / "scripts" / "execute.py")
+
+
 def test_step_success_creates_draft_pr_comments_and_merges(runner, tmp_repo):
     gh_calls = []
     executed = []

--- a/scripts/tests/test_doctor.py
+++ b/scripts/tests/test_doctor.py
@@ -60,6 +60,10 @@ def _write_template_files(root: Path):
         "# 아키텍처\n\n## 시스템 개요\n- Runtime/Framework: <Spring Boot | Python | Node | 기타>\n",
         encoding="utf-8",
     )
+    (root / "docs" / "WORKTREE_LIFECYCLE.md").write_text(
+        "primary checkout harness-worktree.json owner codex-harness safe_cleanup\n",
+        encoding="utf-8",
+    )
     (root / "docs" / "COMMANDS.md").write_text("# Commands\n", encoding="utf-8")
     (root / ".codex" / "project-profile.json").write_text(
         json.dumps(
@@ -249,6 +253,7 @@ def test_required_files_cover_readme_core_operations_contract():
         "scripts/codex_common.py",
         "scripts/doctor.py",
         "scripts/guard.py",
+        "scripts/worktree.py",
     }
 
     assert expected.issubset(set(doctor.REQUIRED_FILES))
@@ -349,6 +354,16 @@ def test_template_mode_detects_bare_python_hook_command(tmp_path):
 
     assert any("through python3" in issue for issue in issues)
     assert any("bare `python` command" in issue for issue in issues)
+
+
+def test_template_mode_detects_incomplete_worktree_contract(tmp_path):
+    _write_template_files(tmp_path)
+    (tmp_path / "docs" / "WORKTREE_LIFECYCLE.md").write_text("primary checkout\n", encoding="utf-8")
+
+    issues = doctor.collect_issues(tmp_path, "template")
+
+    assert any("harness-worktree.json" in issue for issue in issues)
+    assert any("safe_cleanup" in issue for issue in issues)
 
 
 def test_template_mode_detects_missing_line_ending_policy(tmp_path):

--- a/scripts/tests/test_execute.py
+++ b/scripts/tests/test_execute.py
@@ -628,31 +628,27 @@ class TestCheckoutBranch:
         ])
         executor._checkout_branch()  # should return without checkout
 
-    def test_branch_exists_checkout(self, executor):
+    def test_branch_switch_is_refused(self, executor):
         self._mock_git(executor, [
             MagicMock(returncode=0, stdout="main\n", stderr=""),
-            MagicMock(returncode=0, stdout="", stderr=""),
-            MagicMock(returncode=0, stdout="", stderr=""),
         ])
-        executor._checkout_branch()
 
-    def test_branch_not_exists_create(self, executor):
-        self._mock_git(executor, [
-            MagicMock(returncode=0, stdout="main\n", stderr=""),
-            MagicMock(returncode=1, stdout="", stderr="not found"),
-            MagicMock(returncode=0, stdout="", stderr=""),
-        ])
-        executor._checkout_branch()
-
-    def test_checkout_fails_exits(self, executor):
-        self._mock_git(executor, [
-            MagicMock(returncode=0, stdout="main\n", stderr=""),
-            MagicMock(returncode=1, stdout="", stderr=""),
-            MagicMock(returncode=1, stdout="", stderr="dirty tree"),
-        ])
         with pytest.raises(SystemExit) as exc_info:
             executor._checkout_branch()
         assert exc_info.value.code == 1
+
+    def test_wrong_branch_is_not_created_or_checked_out(self, executor):
+        calls = []
+
+        def fake_git(*args):
+            calls.append(args)
+            return MagicMock(returncode=0, stdout="main\n", stderr="")
+
+        executor._run_git = fake_git
+        with pytest.raises(SystemExit):
+            executor._checkout_branch()
+
+        assert all(args[0] not in {"checkout", "switch"} for args in calls)
 
     def test_no_git_exits(self, executor):
         self._mock_git(executor, [

--- a/scripts/tests/test_worktree.py
+++ b/scripts/tests/test_worktree.py
@@ -1,0 +1,315 @@
+import json
+import subprocess
+from pathlib import Path
+from shutil import rmtree
+
+import pytest
+
+import autopilot
+import worktree
+
+
+def git(cwd: Path, *args: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"git {' '.join(args)} failed ({result.returncode}): "
+            f"{result.stdout}\n{result.stderr}"
+        )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> tuple[Path, str]:
+    remote = tmp_path / "remote.git"
+    primary = tmp_path / "primary"
+    git(tmp_path, "init", "--bare", str(remote))
+    git(tmp_path, "clone", str(remote), str(primary))
+    git(primary, "config", "user.name", "Harness Test")
+    git(primary, "config", "user.email", "harness@example.invalid")
+    git(primary, "switch", "-c", "develop")
+    (primary / "README.md").write_text("base\n", encoding="utf-8")
+    git(primary, "add", "README.md")
+    git(primary, "commit", "-m", "base")
+    git(primary, "push", "-u", "origin", "develop")
+    sha = git(primary, "rev-parse", "HEAD")
+    return primary, sha
+
+
+@pytest.fixture
+def lifecycle(git_repo: tuple[Path, str], tmp_path: Path) -> tuple[worktree.WorktreeLifecycle, Path, str]:
+    primary, sha = git_repo
+    manager = worktree.WorktreeLifecycle(
+        primary,
+        worktree_root=tmp_path / "managed-worktrees",
+    )
+    return manager, primary, sha
+
+
+def create_task(manager: worktree.WorktreeLifecycle, *, task_id: str = "phase:task-0", path: Path | None = None):
+    return manager.create_or_resume(
+        task_id=task_id,
+        phase="phase",
+        branch=f"codex/{task_id.replace(':', '-')}",
+        base_ref="refs/remotes/origin/develop",
+        path=path,
+    )
+
+
+def test_create_records_marker_and_preserves_primary_checkout(lifecycle):
+    manager, primary, sha = lifecycle
+
+    handle = create_task(manager)
+
+    assert handle.path.is_absolute()
+    assert handle.path != primary.resolve()
+    assert handle.path.is_relative_to(manager.worktree_root)
+    assert handle.marker_path.exists()
+    payload = json.loads(handle.marker_path.read_text(encoding="utf-8"))
+    assert payload == {
+        "schemaVersion": 1,
+        "owner": "codex-harness",
+        "taskId": "phase:task-0",
+        "phase": "phase",
+        "branch": "codex/phase-task-0",
+        "worktreePath": str(handle.path),
+        "baseRef": "refs/remotes/origin/develop",
+        "baseSha": sha,
+        "status": "created",
+        "createdAt": payload["createdAt"],
+        "updatedAt": payload["updatedAt"],
+    }
+    assert git(primary, "branch", "--show-current") == "develop"
+    assert git(primary, "status", "--porcelain") == ""
+    assert git(handle.path, "branch", "--show-current") == "codex/phase-task-0"
+    assert git(handle.path, "rev-parse", "HEAD") == sha
+
+
+def test_list_and_resume_reuse_same_owned_worktree_and_preserve_diagnostics(lifecycle):
+    manager, _, _ = lifecycle
+    handle = create_task(manager)
+
+    interrupted = manager.transition(
+        handle,
+        "interrupted",
+        error="process interrupted",
+        diagnostics=["pid=1234", "resume from same marker"],
+    )
+    records = manager.list()
+    record = next(item for item in records if item.state.task_id == handle.state.task_id)
+    assert record.stale is False
+    assert record.attached is True
+    assert record.state.status == "interrupted"
+    assert record.marker_path == handle.marker_path
+
+    resumed = manager.resume(handle.state.task_id)
+
+    assert resumed.path == handle.path
+    assert resumed.marker_path == handle.marker_path
+    assert resumed.state.status == "running"
+    assert resumed.state.last_error == interrupted.state.last_error
+    assert "pid=1234" in resumed.state.diagnostics
+    assert resumed.state.resume_count == 1
+
+
+def test_existing_branch_without_marker_is_never_reused(lifecycle):
+    manager, primary, _ = lifecycle
+    git(primary, "branch", "codex/phase-existing")
+
+    with pytest.raises(worktree.WorktreeConflictError, match="branch"):
+        manager.create_or_resume(
+            task_id="phase:existing",
+            phase="phase",
+            branch="codex/phase-existing",
+            base_ref="refs/remotes/origin/develop",
+        )
+
+
+def test_existing_path_without_marker_is_never_deleted(lifecycle, tmp_path: Path):
+    manager, _, _ = lifecycle
+    path = tmp_path / "managed-worktrees" / "manual"
+    path.mkdir(parents=True)
+    sentinel = path / "user-file.txt"
+    sentinel.write_text("preserve me", encoding="utf-8")
+
+    with pytest.raises(worktree.WorktreeConflictError, match="path"):
+        create_task(manager, task_id="phase:manual", path=path)
+
+    assert sentinel.read_text(encoding="utf-8") == "preserve me"
+
+
+def test_stale_administrative_entry_is_reported_and_preserved(lifecycle):
+    manager, _, _ = lifecycle
+    handle = create_task(manager, task_id="phase:stale")
+    rmtree(handle.path)
+
+    records = manager.list()
+    record = next(item for item in records if item.state.task_id == "phase:stale")
+    assert record.stale is True
+    assert record.attached is False
+    assert record.marker_path.exists()
+
+    with pytest.raises(worktree.StaleWorktreeError, match="stale"):
+        manager.resume("phase:stale")
+
+    assert handle.marker_path.exists()
+
+
+def test_foreign_marker_cannot_be_resumed_or_cleaned(lifecycle):
+    manager, _, sha = lifecycle
+    handle = create_task(manager, task_id="phase:foreign")
+    payload = json.loads(handle.marker_path.read_text(encoding="utf-8"))
+    payload["owner"] = "user"
+    handle.marker_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(worktree.WorktreeOwnershipError, match="owner"):
+        manager.resume("phase:foreign")
+
+    with pytest.raises(worktree.WorktreeOwnershipError, match="owner"):
+        manager.safe_cleanup(handle, expected_head_sha=sha)
+
+    assert handle.path.exists()
+
+
+def test_safe_cleanup_requires_merged_clean_owned_head_and_removes_local_branch(lifecycle):
+    manager, primary, sha = lifecycle
+    handle = create_task(manager, task_id="phase:cleanup")
+    merged = manager.transition(handle, "merged", head_sha=sha)
+
+    result = manager.safe_cleanup(merged, expected_head_sha=sha)
+
+    assert result.worktree_removed is True
+    assert result.branch_removed is True
+    assert not handle.path.exists()
+    assert not handle.marker_path.exists()
+    assert git(primary, "show-ref", "--verify", "refs/heads/codex/phase-cleanup", check=False) == ""
+    assert all(item.state.task_id != "phase:cleanup" for item in manager.list())
+
+
+def test_dirty_worktree_is_preserved_even_after_merge_marker(lifecycle):
+    manager, _, sha = lifecycle
+    handle = create_task(manager, task_id="phase:dirty")
+    (handle.path / "dirty.txt").write_text("do not remove", encoding="utf-8")
+    merged = manager.transition(handle, "merged", head_sha=sha)
+
+    with pytest.raises(worktree.WorktreeCleanupError, match="dirty"):
+        manager.safe_cleanup(merged, expected_head_sha=sha)
+
+    assert handle.path.exists()
+    assert handle.marker_path.exists()
+    assert (handle.path / "dirty.txt").read_text(encoding="utf-8") == "do not remove"
+
+
+def test_ignored_file_also_blocks_cleanup(lifecycle):
+    manager, _, sha = lifecycle
+    handle = create_task(manager, task_id="phase:ignored")
+    (handle.path / ".gitignore").write_text("ignored.txt\n", encoding="utf-8")
+    (handle.path / "ignored.txt").write_text("preserve", encoding="utf-8")
+    merged = manager.transition(handle, "merged", head_sha=sha)
+
+    with pytest.raises(worktree.WorktreeCleanupError, match="ignored"):
+        manager.safe_cleanup(merged, expected_head_sha=sha)
+
+    assert handle.path.exists()
+
+
+def test_long_windows_style_managed_path_is_normalized_and_bounded(lifecycle, tmp_path: Path):
+    manager, _, _ = lifecycle
+    long_root = tmp_path / "managed"
+    manager = worktree.WorktreeLifecycle(manager.root, worktree_root=long_root)
+    task_id = "phase:" + ("task-" * 80)
+
+    handle = manager.create_or_resume(
+        task_id=task_id,
+        phase="phase",
+        branch="codex/phase-long-path",
+        base_ref="refs/remotes/origin/develop",
+    )
+
+    assert handle.path.is_absolute()
+    assert handle.path.parent == long_root.resolve()
+    assert len(handle.path.name) <= worktree.MAX_TASK_DIRECTORY_NAME_LENGTH
+
+
+def test_overlong_windows_path_is_rejected_before_git_and_preserves_root(lifecycle, tmp_path: Path):
+    manager, _, _ = lifecycle
+    long_root = tmp_path / ("nested-" * 35)
+    manager = worktree.WorktreeLifecycle(manager.root, worktree_root=long_root)
+
+    with pytest.raises(worktree.WorktreeConflictError, match="안전한 worktree path 길이"):
+        create_task(manager, task_id="phase:long-path")
+
+    assert not long_root.exists()
+
+
+@pytest.mark.parametrize("schema_version", [1, 2])
+def test_serial_v1_v2_task_worktrees_are_isolated(lifecycle, schema_version):
+    manager, primary, sha = lifecycle
+    runner = autopilot.AutopilotRunner(
+        "phase",
+        root=primary,
+        worktree_root=manager.worktree_root,
+    )
+    runner._base_ref = "refs/remotes/origin/develop"
+    runner._base_sha = sha
+
+    first_step = {"step": 0, "name": "first"}
+    second_step = {"step": 1, "name": "second"}
+    if schema_version == 2:
+        first_step["id"] = "task-first"
+        second_step["id"] = "task-second"
+
+    first = runner._task_worktree(first_step)
+    second = runner._task_worktree(second_step)
+    first_only = first.path / "task-only.txt"
+    second_only = second.path / "task-two-only.txt"
+    first_only.write_text("first task", encoding="utf-8")
+    second_only.write_text("second task", encoding="utf-8")
+
+    assert not (first.path / "task-two-only.txt").exists()
+    assert not (second.path / "task-only.txt").exists()
+    assert git(primary, "branch", "--show-current") == "develop"
+
+    first_only.unlink()
+    second_only.unlink()
+    for handle in (first, second):
+        merged = runner._lifecycle.transition(handle, "merged", head_sha=sha)
+        runner._lifecycle.safe_cleanup(merged, expected_head_sha=sha)
+
+
+def test_autopilot_failure_preserves_task_worktree_for_resume(lifecycle):
+    manager, primary, sha = lifecycle
+    runner = autopilot.AutopilotRunner(
+        "phase",
+        base="develop",
+        root=primary,
+        worktree_root=manager.worktree_root,
+    )
+    runner._base_ref = "refs/remotes/origin/develop"
+    runner._base_sha = sha
+    step = {"step": 0, "name": "failure"}
+    handle = runner._task_worktree(step)
+
+    runner._ensure_preconditions = lambda: None
+    runner._next_pending_step = lambda: step
+    runner._task_worktree = lambda current_step: handle
+
+    def fail_step(branch, current_step):
+        raise autopilot.AutopilotError("implementation failed")
+
+    runner._run_step = fail_step
+
+    with pytest.raises(autopilot.AutopilotError, match="implementation failed"):
+        runner.run()
+
+    record = next(item for item in manager.list() if item.state.task_id == handle.state.task_id)
+    assert record.state.status == "error"
+    assert record.state.last_error == "implementation failed"
+    assert record.path.exists()
+    assert record.marker_path.exists()

--- a/scripts/tests/test_worktree.py
+++ b/scripts/tests/test_worktree.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 from pathlib import Path
 from shutil import rmtree
@@ -237,6 +238,7 @@ def test_long_windows_style_managed_path_is_normalized_and_bounded(lifecycle, tm
     assert len(handle.path.name) <= worktree.MAX_TASK_DIRECTORY_NAME_LENGTH
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows Git path limit is platform-specific")
 def test_overlong_windows_path_is_rejected_before_git_and_preserves_root(lifecycle, tmp_path: Path):
     manager, _, _ = lifecycle
     long_root = tmp_path / ("nested-" * 35)

--- a/scripts/worktree.py
+++ b/scripts/worktree.py
@@ -1,0 +1,788 @@
+#!/usr/bin/env python3
+"""Harness가 소유한 task별 Git worktree의 생성·재개·정리 lifecycle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable
+
+
+OWNER = "codex-harness"
+MARKER_FILENAME = "harness-worktree.json"
+MARKER_SCHEMA_VERSION = 1
+MAX_TASK_DIRECTORY_NAME_LENGTH = 80
+# Git for Windows can reject a linked worktree before the OS long-path policy
+# is consulted (for example, ``fatal: '$GIT_DIR' too big``). Keep a margin for
+# the admin path and Git metadata instead of discovering this after ``add``.
+MAX_WINDOWS_WORKTREE_PATH_LENGTH = 240
+VALID_STATUSES = frozenset(
+    {
+        "created",
+        "running",
+        "implemented",
+        "reviewing",
+        "ready",
+        "merged",
+        "error",
+        "blocked",
+        "interrupted",
+    }
+)
+PRESERVED_STATUSES = frozenset({"error", "blocked", "interrupted"})
+
+
+class WorktreeLifecycleError(RuntimeError):
+    """Worktree lifecycle를 안전하게 진행할 수 없을 때 발생한다."""
+
+
+class WorktreeConflictError(WorktreeLifecycleError):
+    """기존 branch, path 또는 admin entry와 충돌한다."""
+
+
+class WorktreeOwnershipError(WorktreeLifecycleError):
+    """Harness가 소유하지 않은 marker를 조작하려 했다."""
+
+
+class StaleWorktreeError(WorktreeLifecycleError):
+    """Git admin entry와 실제 worktree 상태가 어긋났다."""
+
+
+class WorktreeCleanupError(WorktreeLifecycleError):
+    """검증되지 않은 worktree를 정리하려 했다."""
+
+
+@dataclass(frozen=True)
+class WorktreeState:
+    task_id: str
+    phase: str
+    branch: str
+    worktree_path: Path
+    base_ref: str
+    base_sha: str
+    status: str = "created"
+    owner: str = OWNER
+    schema_version: int = MARKER_SCHEMA_VERSION
+    head_sha: str | None = None
+    created_at: str = ""
+    updated_at: str = ""
+    last_error: str | None = None
+    diagnostics: tuple[str, ...] = field(default_factory=tuple)
+    resume_count: int = 0
+
+    @property
+    def path(self) -> Path:
+        return self.worktree_path
+
+    def to_payload(self) -> dict:
+        payload = {
+            "schemaVersion": self.schema_version,
+            "owner": self.owner,
+            "taskId": self.task_id,
+            "phase": self.phase,
+            "branch": self.branch,
+            "worktreePath": str(self.worktree_path),
+            "baseRef": self.base_ref,
+            "baseSha": self.base_sha,
+            "status": self.status,
+            "createdAt": self.created_at,
+            "updatedAt": self.updated_at,
+        }
+        if self.head_sha:
+            payload["headSha"] = self.head_sha
+        if self.last_error:
+            payload["lastError"] = self.last_error
+        if self.diagnostics:
+            payload["diagnostics"] = list(self.diagnostics)
+        if self.resume_count:
+            payload["resumeCount"] = self.resume_count
+        return payload
+
+    @classmethod
+    def from_payload(cls, payload: object, *, marker_path: Path) -> "WorktreeState":
+        if not isinstance(payload, dict):
+            raise WorktreeLifecycleError(f"marker가 object가 아닙니다: {marker_path}")
+
+        def required_string(key: str) -> str:
+            value = payload.get(key)
+            if not isinstance(value, str) or not value:
+                raise WorktreeLifecycleError(f"marker의 {key}가 비어 있습니다: {marker_path}")
+            return value
+
+        schema_version = payload.get("schemaVersion")
+        if schema_version != MARKER_SCHEMA_VERSION:
+            raise WorktreeLifecycleError(
+                f"지원하지 않는 worktree marker schemaVersion={schema_version}: {marker_path}"
+            )
+
+        status = required_string("status")
+        if status not in VALID_STATUSES:
+            raise WorktreeLifecycleError(f"지원하지 않는 worktree 상태 {status!r}: {marker_path}")
+
+        raw_path = required_string("worktreePath")
+        path = Path(raw_path)
+        if not path.is_absolute():
+            raise WorktreeLifecycleError(f"worktreePath는 absolute path여야 합니다: {marker_path}")
+
+        diagnostics = payload.get("diagnostics", [])
+        if not isinstance(diagnostics, list) or not all(isinstance(item, str) for item in diagnostics):
+            raise WorktreeLifecycleError(f"marker의 diagnostics가 올바르지 않습니다: {marker_path}")
+
+        resume_count = payload.get("resumeCount", 0)
+        if not isinstance(resume_count, int) or resume_count < 0:
+            raise WorktreeLifecycleError(f"marker의 resumeCount가 올바르지 않습니다: {marker_path}")
+
+        owner = required_string("owner")
+        return cls(
+            task_id=required_string("taskId"),
+            phase=required_string("phase"),
+            branch=required_string("branch"),
+            worktree_path=path.resolve(strict=False),
+            base_ref=required_string("baseRef"),
+            base_sha=required_string("baseSha"),
+            status=status,
+            owner=owner,
+            schema_version=schema_version,
+            head_sha=payload.get("headSha") if isinstance(payload.get("headSha"), str) else None,
+            created_at=required_string("createdAt"),
+            updated_at=required_string("updatedAt"),
+            last_error=payload.get("lastError") if isinstance(payload.get("lastError"), str) else None,
+            diagnostics=tuple(diagnostics),
+            resume_count=resume_count,
+        )
+
+
+@dataclass(frozen=True)
+class WorktreeHandle:
+    state: WorktreeState
+    marker_path: Path
+
+    @property
+    def path(self) -> Path:
+        return self.state.worktree_path
+
+    @property
+    def task_id(self) -> str:
+        return self.state.task_id
+
+    @property
+    def branch(self) -> str:
+        return self.state.branch
+
+
+@dataclass(frozen=True)
+class WorktreeRecord:
+    state: WorktreeState
+    marker_path: Path
+    attached: bool
+    stale: bool
+    head_sha: str | None = None
+    branch: str | None = None
+
+    @property
+    def path(self) -> Path:
+        return self.state.worktree_path
+
+
+@dataclass(frozen=True)
+class CleanupResult:
+    worktree_removed: bool
+    branch_removed: bool
+    diagnostics: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class _GitWorktreeEntry:
+    path: Path
+    head_sha: str | None
+    branch: str | None
+
+
+class WorktreeLifecycle:
+    """하나의 primary checkout에서 Harness-owned linked worktree를 관리한다.
+
+    이 객체는 primary checkout의 branch를 바꾸지 않는다. 생성은 ``git
+    worktree add -b``로만 수행하고, 정리는 owner/status/head/clean 검증을
+    모두 통과한 경우에만 non-force 명령으로 수행한다.
+    """
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        worktree_root: Path | None = None,
+        clock: Callable[[], str] | None = None,
+        git_timeout: int = 600,
+    ):
+        self.root = Path(root).resolve()
+        self.worktree_root = (
+            Path(worktree_root).resolve()
+            if worktree_root is not None
+            else (self.root.parent / ".codex-worktrees" / self.root.name).resolve()
+        )
+        if self.worktree_root == self.root or self.worktree_root.is_relative_to(self.root) or self.root.is_relative_to(self.worktree_root):
+            raise WorktreeConflictError(
+                "managed worktree root와 primary checkout은 서로 겹치면 안 됩니다: "
+                f"primary={self.root}, managed={self.worktree_root}"
+            )
+        self.clock = clock or self._now
+        self.git_timeout = git_timeout
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    def _run_git(
+        self,
+        *args: str,
+        cwd: Path | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        command = ["git", *args]
+        try:
+            result = subprocess.run(
+                command,
+                cwd=cwd or self.root,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=self.git_timeout,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise WorktreeLifecycleError(f"`{' '.join(command)}` 실행 실패: {exc}") from exc
+        if check and result.returncode != 0:
+            output = "\n".join(
+                part.strip() for part in (result.stdout, result.stderr) if part and part.strip()
+            )
+            raise WorktreeLifecycleError(
+                f"`{' '.join(command)}` 실패: {output or f'exit {result.returncode}'}"
+            )
+        return result
+
+    def _git_path(self, name: str) -> Path:
+        result = self._run_git("rev-parse", "--git-path", name)
+        raw = Path(result.stdout.strip())
+        return raw if raw.is_absolute() else (self.root / raw).resolve()
+
+    @staticmethod
+    def _safe_task_slug(task_id: str) -> str:
+        slug = re.sub(r"[^A-Za-z0-9._-]+", "-", task_id).strip(".-")
+        if not slug:
+            slug = "task"
+        slug = slug[:MAX_TASK_DIRECTORY_NAME_LENGTH].rstrip(".-") or "task"
+        if slug.upper() in {"CON", "PRN", "AUX", "NUL"} or re.fullmatch(r"COM[1-9]", slug.upper()):
+            slug = f"task-{slug}"
+        return slug
+
+    def _managed_path(self, task_id: str, requested: Path | None) -> Path:
+        path = requested or (self.worktree_root / self._safe_task_slug(task_id))
+        path = Path(path).resolve(strict=False)
+        managed_root = self.worktree_root.resolve(strict=False)
+        if path == self.root or path == managed_root or not path.is_relative_to(managed_root):
+            raise WorktreeConflictError(
+                f"task worktree path는 managed worktree root 안이어야 합니다: {path}"
+            )
+        if os.name == "nt" and len(str(path)) > MAX_WINDOWS_WORKTREE_PATH_LENGTH:
+            raise WorktreeConflictError(
+                "Windows Git이 처리할 수 있는 안전한 worktree path 길이를 초과했습니다. "
+                f"짧은 --worktree-root를 지정하세요 (length={len(str(path))}, "
+                f"limit={MAX_WINDOWS_WORKTREE_PATH_LENGTH}): {path}"
+            )
+        return path
+
+    def _worktree_entries(self) -> list[_GitWorktreeEntry]:
+        result = self._run_git("worktree", "list", "--porcelain")
+        entries: list[_GitWorktreeEntry] = []
+        current_path: Path | None = None
+        current_head: str | None = None
+        current_branch: str | None = None
+
+        def flush() -> None:
+            nonlocal current_path, current_head, current_branch
+            if current_path is not None:
+                entries.append(_GitWorktreeEntry(current_path.resolve(strict=False), current_head, current_branch))
+            current_path = None
+            current_head = None
+            current_branch = None
+
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                flush()
+            elif line.startswith("worktree "):
+                flush()
+                current_path = Path(line[len("worktree ") :].strip())
+            elif line.startswith("HEAD "):
+                current_head = line[len("HEAD ") :].strip()
+            elif line.startswith("branch "):
+                ref = line[len("branch ") :].strip()
+                current_branch = ref.removeprefix("refs/heads/")
+        flush()
+        return entries
+
+    def _admin_dirs(self) -> list[Path]:
+        admin_root = self._git_path("worktrees")
+        if not admin_root.is_dir():
+            return []
+        return sorted(
+            (path for path in admin_root.iterdir() if path.is_dir() and (path / "gitdir").is_file()),
+            key=lambda path: str(path).casefold(),
+        )
+
+    def _marker_records(self) -> list[WorktreeRecord]:
+        entries = self._worktree_entries()
+        records: list[WorktreeRecord] = []
+        for admin_dir in self._admin_dirs():
+            marker_path = admin_dir / MARKER_FILENAME
+            if not marker_path.is_file():
+                continue
+            try:
+                payload = json.loads(marker_path.read_text(encoding="utf-8"))
+                state = WorktreeState.from_payload(payload, marker_path=marker_path)
+            except (OSError, json.JSONDecodeError, WorktreeLifecycleError):
+                raise
+            entry = next(
+                (
+                    item
+                    for item in entries
+                    if item.path == state.worktree_path and item.branch == state.branch
+                ),
+                None,
+            )
+            attached = entry is not None and state.worktree_path.exists()
+            stale = not attached or entry is None or entry.branch != state.branch
+            records.append(
+                WorktreeRecord(
+                    state=state,
+                    marker_path=marker_path,
+                    attached=attached,
+                    stale=stale,
+                    head_sha=entry.head_sha if entry else None,
+                    branch=entry.branch if entry else None,
+                )
+            )
+        return records
+
+    def list(self) -> list[WorktreeRecord]:
+        """현재 Harness marker와 stale 여부를 읽는다. Git admin은 변경하지 않는다."""
+        return self._marker_records()
+
+    def _find_admin_for_path(self, path: Path) -> Path:
+        resolved = path.resolve(strict=False)
+        entries = self._worktree_entries()
+        if not any(item.path == resolved for item in entries):
+            raise WorktreeLifecycleError(f"생성한 worktree를 Git admin에서 확인할 수 없습니다: {resolved}")
+
+        git_file = resolved / ".git"
+        if git_file.is_file():
+            raw = git_file.read_text(encoding="utf-8").strip()
+            if raw.startswith("gitdir:"):
+                admin = Path(raw[len("gitdir:") :].strip())
+                if not admin.is_absolute():
+                    admin = (resolved / admin).resolve()
+                admin = admin.resolve(strict=False)
+                if (admin / "gitdir").is_file():
+                    return admin
+
+        for admin_dir in self._admin_dirs():
+            marker = admin_dir / MARKER_FILENAME
+            if marker.exists():
+                try:
+                    payload = json.loads(marker.read_text(encoding="utf-8"))
+                    state = WorktreeState.from_payload(payload, marker_path=marker)
+                except (OSError, json.JSONDecodeError, WorktreeLifecycleError):
+                    continue
+                if state.worktree_path == resolved:
+                    return admin_dir
+        raise WorktreeLifecycleError(f"worktree admin directory를 찾지 못했습니다: {resolved}")
+
+    @staticmethod
+    def _assert_owner(state: WorktreeState, marker_path: Path) -> None:
+        if state.owner != OWNER:
+            raise WorktreeOwnershipError(
+                f"Harness가 소유하지 않은 worktree marker입니다 (owner={state.owner!r}): {marker_path}"
+            )
+
+    def _resolve_base_sha(self, base_ref: str, base_sha: str | None) -> str:
+        result = self._run_git("rev-parse", "--verify", f"{base_ref}^{{commit}}")
+        resolved = result.stdout.strip()
+        if not resolved:
+            raise WorktreeLifecycleError(f"base ref의 SHA를 확인하지 못했습니다: {base_ref}")
+        if base_sha is not None and resolved != base_sha:
+            raise WorktreeConflictError(
+                f"base ref와 base SHA가 다릅니다: {base_ref}={resolved}, marker/request={base_sha}"
+            )
+        return base_sha or resolved
+
+    def _write_state(self, marker_path: Path, state: WorktreeState) -> None:
+        marker_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(state.to_payload(), ensure_ascii=False, indent=2) + "\n"
+        fd, temp_name = tempfile.mkstemp(
+            prefix=f".{MARKER_FILENAME}.", suffix=".tmp", dir=str(marker_path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_name, marker_path)
+        finally:
+            Path(temp_name).unlink(missing_ok=True)
+
+    def _handle_from_record(self, record: WorktreeRecord) -> WorktreeHandle:
+        return WorktreeHandle(record.state, record.marker_path)
+
+    def create_or_resume(
+        self,
+        *,
+        task_id: str,
+        phase: str,
+        branch: str,
+        base_ref: str,
+        base_sha: str | None = None,
+        path: Path | None = None,
+    ) -> WorktreeHandle:
+        """동일 task marker가 있으면 재사용하고, 없으면 새 linked worktree를 만든다."""
+        if not task_id or not phase or not branch or not base_ref:
+            raise WorktreeLifecycleError("task_id, phase, branch, base_ref는 필수입니다.")
+        expected_path = self._managed_path(task_id, path)
+        records = self._marker_records()
+
+        same_task = [record for record in records if record.state.task_id == task_id]
+        if len(same_task) > 1:
+            raise WorktreeConflictError(f"task marker가 여러 개라 재개할 수 없습니다: {task_id}")
+        if same_task:
+            record = same_task[0]
+            self._assert_owner(record.state, record.marker_path)
+            state = record.state
+            if (
+                state.phase != phase
+                or state.branch != branch
+                or state.worktree_path != expected_path
+                or state.base_ref != base_ref
+                or (base_sha is not None and state.base_sha != base_sha)
+            ):
+                raise WorktreeConflictError(f"기존 task marker와 요청이 다릅니다: {task_id}")
+            if state.status == "merged":
+                raise WorktreeConflictError(f"이미 merged 상태인 task는 재사용할 수 없습니다: {task_id}")
+            if record.stale:
+                raise StaleWorktreeError(
+                    f"stale worktree marker를 자동 복구하지 않습니다: {record.marker_path}"
+                )
+            object_exists = self._run_git(
+                "cat-file",
+                "-e",
+                f"{state.base_sha}^{{commit}}",
+                check=False,
+            )
+            if object_exists.returncode != 0:
+                raise StaleWorktreeError(
+                    f"marker의 pinned base SHA를 local object에서 찾지 못했습니다: {state.base_sha}"
+                )
+            return self._handle_from_record(record)
+
+        resolved_base_sha = self._resolve_base_sha(base_ref, base_sha)
+        entries = self._worktree_entries()
+        for record in records:
+            if record.state.worktree_path == expected_path or record.state.branch == branch:
+                self._assert_owner(record.state, record.marker_path)
+                raise WorktreeConflictError(
+                    f"다른 task가 이미 사용하는 worktree path 또는 branch입니다: {expected_path} / {branch}"
+                )
+        for entry in entries:
+            if entry.path == expected_path or entry.branch == branch:
+                raise WorktreeConflictError(
+                    f"기존 Git worktree와 충돌합니다 (path/branch): {expected_path} / {branch}"
+                )
+        if expected_path.exists():
+            raise WorktreeConflictError(f"기존 path를 삭제하거나 덮어쓰지 않습니다: {expected_path}")
+        branch_ref = f"refs/heads/{branch}"
+        branch_exists = self._run_git("show-ref", "--verify", branch_ref, check=False)
+        if branch_exists.returncode == 0:
+            raise WorktreeConflictError(f"기존 branch를 재사용하거나 덮어쓰지 않습니다: {branch}")
+
+        expected_path.parent.mkdir(parents=True, exist_ok=True)
+        self._run_git("worktree", "add", "-b", branch, str(expected_path), base_ref)
+
+        try:
+            admin_dir = self._find_admin_for_path(expected_path)
+            now = self.clock()
+            state = WorktreeState(
+                task_id=task_id,
+                phase=phase,
+                branch=branch,
+                worktree_path=expected_path,
+                base_ref=base_ref,
+                base_sha=resolved_base_sha,
+                created_at=now,
+                updated_at=now,
+            )
+            marker_path = admin_dir / MARKER_FILENAME
+            self._write_state(marker_path, state)
+            current_entries = self._worktree_entries()
+            entry = next(
+                (item for item in current_entries if item.path == expected_path and item.branch == branch),
+                None,
+            )
+            if entry is None or entry.head_sha != resolved_base_sha:
+                raise WorktreeLifecycleError(
+                    f"생성 직후 worktree 검증 실패: path/branch/head={expected_path}/{branch}/{entry.head_sha if entry else None}"
+                )
+            return WorktreeHandle(state, marker_path)
+        except Exception as exc:
+            raise WorktreeLifecycleError(
+                f"worktree marker/생성 검증에 실패했습니다. worktree는 진단을 위해 보존됩니다: {expected_path}; {exc}"
+            ) from exc
+
+    def _find_task_record(self, task_id: str) -> WorktreeRecord:
+        matches = [record for record in self._marker_records() if record.state.task_id == task_id]
+        if not matches:
+            raise WorktreeLifecycleError(f"task marker를 찾지 못했습니다: {task_id}")
+        if len(matches) > 1:
+            raise WorktreeConflictError(f"task marker가 여러 개입니다: {task_id}")
+        return matches[0]
+
+    def resume(self, task_id: str) -> WorktreeHandle:
+        record = self._find_task_record(task_id)
+        self._assert_owner(record.state, record.marker_path)
+        if record.stale:
+            raise StaleWorktreeError(
+                f"stale worktree를 자동 복구하지 않습니다. marker와 진단을 확인하세요: {record.marker_path}"
+            )
+        if record.state.status == "merged":
+            raise WorktreeConflictError(f"이미 merged 상태인 task는 재개할 수 없습니다: {task_id}")
+        return self.transition(
+            self._handle_from_record(record),
+            "running",
+            resume_count=record.state.resume_count + 1,
+        )
+
+    def transition(
+        self,
+        handle: WorktreeHandle,
+        status: str,
+        *,
+        head_sha: str | None = None,
+        error: str | None = None,
+        diagnostics: Iterable[str] = (),
+        resume_count: int | None = None,
+    ) -> WorktreeHandle:
+        if status not in VALID_STATUSES:
+            raise WorktreeLifecycleError(f"지원하지 않는 worktree 상태입니다: {status}")
+        marker_path = handle.marker_path
+        try:
+            payload = json.loads(marker_path.read_text(encoding="utf-8"))
+            current = WorktreeState.from_payload(payload, marker_path=marker_path)
+        except (OSError, json.JSONDecodeError, WorktreeLifecycleError) as exc:
+            raise WorktreeLifecycleError(f"worktree marker를 읽지 못했습니다: {marker_path}: {exc}") from exc
+        self._assert_owner(current, marker_path)
+        merged_diagnostics = list(current.diagnostics)
+        for item in diagnostics:
+            if item and item not in merged_diagnostics:
+                merged_diagnostics.append(str(item))
+        updated = replace(
+            current,
+            status=status,
+            updated_at=self.clock(),
+            head_sha=head_sha or current.head_sha,
+            last_error=error or current.last_error,
+            diagnostics=tuple(merged_diagnostics),
+            resume_count=current.resume_count if resume_count is None else resume_count,
+        )
+        self._write_state(marker_path, updated)
+        return WorktreeHandle(updated, marker_path)
+
+    def _record_cleanup_failure(self, handle: WorktreeHandle, message: str) -> None:
+        try:
+            self.transition(handle, handle.state.status, error=message, diagnostics=[message])
+        except WorktreeLifecycleError:
+            pass
+
+    def safe_cleanup(
+        self,
+        handle: WorktreeHandle,
+        *,
+        expected_head_sha: str | None = None,
+    ) -> CleanupResult:
+        """merged + owned + clean + expected HEAD일 때만 non-force cleanup한다."""
+        marker_path = handle.marker_path
+        try:
+            payload = json.loads(marker_path.read_text(encoding="utf-8"))
+            state = WorktreeState.from_payload(payload, marker_path=marker_path)
+        except (OSError, json.JSONDecodeError, WorktreeLifecycleError) as exc:
+            raise WorktreeCleanupError(f"cleanup marker를 읽지 못했습니다: {marker_path}: {exc}") from exc
+        self._assert_owner(state, marker_path)
+        if state.status != "merged":
+            raise WorktreeCleanupError(
+                f"merged 상태가 아니므로 cleanup하지 않습니다: {state.task_id} status={state.status}"
+            )
+        path = state.worktree_path.resolve(strict=False)
+        managed_root = self.worktree_root.resolve(strict=False)
+        if path == self.root or path == managed_root or not path.is_relative_to(managed_root):
+            raise WorktreeCleanupError(f"managed worktree 밖의 path는 cleanup하지 않습니다: {path}")
+
+        entries = self._worktree_entries()
+        entry = next((item for item in entries if item.path == path), None)
+        if entry is None or entry.branch != state.branch:
+            message = f"Git admin entry가 stale 또는 branch 불일치라 cleanup하지 않습니다: {path}"
+            self._record_cleanup_failure(handle, message)
+            raise WorktreeCleanupError(message)
+        if not path.is_dir():
+            message = f"worktree path가 없어 cleanup하지 않습니다: {path}"
+            self._record_cleanup_failure(handle, message)
+            raise WorktreeCleanupError(message)
+
+        status = self._run_git(
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--ignored",
+            cwd=path,
+            check=False,
+        )
+        if status.returncode != 0:
+            message = f"worktree status를 확인하지 못해 cleanup하지 않습니다: {status.stderr.strip()}"
+            self._record_cleanup_failure(handle, message)
+            raise WorktreeCleanupError(message)
+        status_lines = [line for line in status.stdout.splitlines() if line.strip()]
+        if status_lines:
+            kind = "ignored" if any(line.startswith("!!") for line in status_lines) else "dirty"
+            message = f"{kind} 변경이 남아 있어 cleanup하지 않습니다: {'; '.join(status_lines[:8])}"
+            self._record_cleanup_failure(handle, message)
+            raise WorktreeCleanupError(message)
+
+        current_head_result = self._run_git("rev-parse", "HEAD", cwd=path)
+        current_head = current_head_result.stdout.strip()
+        expected_head = expected_head_sha or state.head_sha
+        if not expected_head:
+            message = "merged marker에 expected head SHA가 없어 cleanup하지 않습니다"
+            self._record_cleanup_failure(handle, message)
+            raise WorktreeCleanupError(message)
+        if current_head != expected_head or (entry.head_sha and entry.head_sha != expected_head):
+            message = (
+                f"HEAD가 expected SHA와 달라 cleanup하지 않습니다: current={current_head}, "
+                f"admin={entry.head_sha}, expected={expected_head}"
+            )
+            self._record_cleanup_failure(handle, message)
+            raise WorktreeCleanupError(message)
+
+        remove_result = self._run_git("worktree", "remove", str(path), check=False)
+        if remove_result.returncode != 0:
+            output = "\n".join(
+                part.strip() for part in (remove_result.stdout, remove_result.stderr) if part and part.strip()
+            )
+            message = f"worktree non-force remove 실패. path와 marker를 보존합니다: {output or remove_result.returncode}"
+            self._record_cleanup_failure(handle, message)
+            raise WorktreeCleanupError(message)
+
+        diagnostics: list[str] = []
+        branch_result = self._run_git("branch", "-d", state.branch, check=False)
+        branch_removed = branch_result.returncode == 0
+        if not branch_removed:
+            output = "\n".join(
+                part.strip() for part in (branch_result.stdout, branch_result.stderr) if part and part.strip()
+            )
+            diagnostics.append(f"Harness-owned local branch를 non-force 삭제하지 못했습니다: {output or branch_result.returncode}")
+        return CleanupResult(True, branch_removed, tuple(diagnostics))
+
+    def create_validation_worktree(self, *, base_ref: str, base_sha: str) -> Path:
+        """base 검증용 detached checkout을 만든다.
+
+        이 checkout은 task marker를 만들지 않는 ephemeral 상태다. 호출자는
+        반드시 ``remove_validation_worktree``를 호출해야 하며, dirty 상태면
+        remove가 실패해 진단을 보존한다.
+        """
+        self._resolve_base_sha(base_ref, base_sha)
+        path = (self.worktree_root / f".base-validation-{base_sha[:12]}").resolve()
+        if path == self.root or path == self.worktree_root.resolve(strict=False) or not path.is_relative_to(self.worktree_root.resolve(strict=False)):
+            raise WorktreeConflictError(f"base validation path가 managed root 밖입니다: {path}")
+        if path.exists():
+            raise WorktreeConflictError(f"기존 base validation path를 덮어쓰지 않습니다: {path}")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._run_git("worktree", "add", "--detach", str(path), base_ref)
+        entries = self._worktree_entries()
+        entry = next((item for item in entries if item.path == path), None)
+        if entry is None or entry.head_sha != base_sha:
+            raise WorktreeLifecycleError(f"base validation worktree 생성 검증 실패: {path}")
+        return path
+
+    def remove_validation_worktree(self, path: Path) -> None:
+        path = Path(path).resolve(strict=False)
+        status = self._run_git(
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--ignored",
+            cwd=path,
+            check=False,
+        )
+        if status.returncode != 0:
+            raise WorktreeCleanupError(f"base validation status 확인 실패: {path}: {status.stderr.strip()}")
+        if status.stdout.strip():
+            raise WorktreeCleanupError(
+                f"base validation worktree가 dirty라 보존합니다: {path}: {status.stdout.strip()}"
+            )
+        result = self._run_git("worktree", "remove", str(path), check=False)
+        if result.returncode != 0:
+            output = "\n".join(
+                part.strip() for part in (result.stdout, result.stderr) if part and part.strip()
+            )
+            raise WorktreeCleanupError(f"base validation worktree remove 실패: {path}: {output}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="List, resume, or safely clean Harness task worktrees.")
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="primary checkout")
+    parser.add_argument("--worktree-root", type=Path, help="managed worktree root")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("list", help="list Harness markers and stale state")
+    resume = subparsers.add_parser("resume", help="resume an existing task marker")
+    resume.add_argument("task_id")
+    cleanup = subparsers.add_parser("cleanup", help="safely clean a merged task worktree")
+    cleanup.add_argument("task_id")
+    cleanup.add_argument("--expected-head-sha")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    lifecycle = WorktreeLifecycle(args.root, worktree_root=args.worktree_root)
+    try:
+        if args.command == "list":
+            for record in lifecycle.list():
+                print(
+                    json.dumps(
+                        {
+                            **record.state.to_payload(),
+                            "markerPath": str(record.marker_path),
+                            "attached": record.attached,
+                            "stale": record.stale,
+                            "adminHeadSha": record.head_sha,
+                        },
+                        ensure_ascii=False,
+                    )
+                )
+        elif args.command == "resume":
+            print(json.dumps(lifecycle.resume(args.task_id).state.to_payload(), ensure_ascii=False))
+        else:
+            result = lifecycle.safe_cleanup(
+                lifecycle._handle_from_record(lifecycle._find_task_record(args.task_id)),
+                expected_head_sha=args.expected_head_sha,
+            )
+            print(json.dumps(result.__dict__, ensure_ascii=False))
+        return 0
+    except WorktreeLifecycleError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 작업 내용
- Task별 Git worktree lifecycle(create/list/resume/safe cleanup)과 Git admin marker를 추가했습니다.
- autopilot의 구현·검증·read-only review·PR 준비를 task worktree로 옮기고 primary branch switch/commit/stage를 제거했습니다.
- v1 steps[]와 v2 tasks[]의 list-order 직렬 실행, concurrency 1, Windows/stale/기존 branch·path/실패 보존 테스트와 문서·ADR·doctor·migration 계약을 갱신했습니다.

## 변경 이유
primary checkout과 사용자 변경을 보존하면서 실패 task를 진단·resume하고, merge 성공 task만 검증된 non-force cleanup하기 위해서입니다.

## 상태·소유권
- marker: Git administrative directory의 harness-worktree.json
- owner: codex-harness
- base: remote ref와 pinned full SHA
- 실패/error/blocked/interrupted: worktree와 marker 보존
- 성공: merged/clean/expected HEAD/active entry 검증 후에만 cleanup
- 사용자 worktree/branch 및 stale administrative entry: 자동 삭제·이동·prune하지 않음

## 테스트 및 확인
- uv run --with pytest python -X utf8 -m pytest scripts
- 222 passed
- uv run --with pytest python -X utf8 -m pytest scripts/tests/test_execute.py scripts/tests/test_autopilot.py
- 121 passed
- uv run python -X utf8 -m compileall -q scripts
- uv run python -X utf8 scripts/doctor.py --template
- uv run python -X utf8 scripts/checks.py --docs-check-config phases/harness-v2-modernization/docs-checks.json --docs-check
- git diff --check

템플릿은 실제 프로젝트의 test/build 명령이 비어 있어 checks.py --stage manual은 	est, build placeholder 오류를 반환합니다. 이는 이번 변경과 무관한 기존 템플릿 제한입니다.

## 범위 제한
#22의 DAG/ready-set/병렬·bounded concurrency, SDK/native review adapter/telemetry는 구현하지 않았습니다.

Closes #17