### PR TITLE
feat: Python Codex SDK 전환 가능성 검증

### DIFF
--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -10,3 +10,4 @@
 - [ADR-0002: Codex subprocess 환경 상속 최소화](adr/0002-minimize-codex-environment.md)
 - [ADR-0003: Outcome task schema v2와 v1 호환](adr/0003-outcome-task-schema-v2.md)
 - [ADR-0004: Isolated task worktree lifecycle](adr/0004-isolated-task-worktrees.md)
+- [ADR-0005: Python Codex SDK 조건부 도입과 exec fallback](adr/0005-python-codex-sdk-spike.md)

--- a/docs/adr/0005-python-codex-sdk-spike.md
+++ b/docs/adr/0005-python-codex-sdk-spike.md
@@ -1,0 +1,79 @@
+# ADR-0005: Python Codex SDK 조건부 도입과 exec fallback
+
+- 상태: Accepted
+- 날짜: 2026-09-06
+- 관련 이슈: #18
+- 결정 식별자: SDK-CONDITIONAL-GO-0.147.0-EXEC-FALLBACK
+
+## 문맥
+
+현재 Harness는 `codex exec --json` subprocess를 구현, review와 fix에 사용한다.
+stable Python SDK가 같은 기능을 typed API, 지속 thread와 직접 interrupt로 제공하면
+Step 6 이후 runner 경계를 단순화할 수 있다. 반면 spike에서 검증하지 않은 API나
+실험적 App Server surface를 기본 경로로 만들면 기존 v1 호환, sandbox, approval와
+read-only review gate를 약화시킬 수 있다.
+
+공식 문서와 `openai-codex==0.147.0` live spike 결과는
+[`SDK_SPIKE.md`](../../phases/harness-v2-modernization/SDK_SPIKE.md)와 sanitized
+[`SDK_SPIKE_RESULTS.json`](../../phases/harness-v2-modernization/SDK_SPIKE_RESULTS.json)에
+고정한다.
+
+## 결정
+
+**조건부 GO**로 결정한다. 이 GO는 Step 6에서 opt-in SDK runner adapter를 설계할
+수 있다는 뜻이며, production 기본 경로를 SDK로 전환한다는 뜻이 아니다.
+
+1. 다음 adapter spike 기준은 `openai-codex==0.147.0`과 자동 설치되는
+   `openai-codex-cli-bin==0.147.0`으로 고정한다.
+2. 현재 `codex exec` runner와 read-only review를 기본 fallback으로 유지한다.
+3. SDK adapter는 feature flag 기본 off, missing/version mismatch/auth/model/sandbox/
+   approval/timeout/interrupt/output failure 시 fail-closed exec fallback을 전제로 한다.
+4. SDK에는 native turn timeout이 없으므로 caller deadline, active turn interrupt,
+   terminal wait, client close 순서가 검증되기 전에는 Harness timeout을 대체하지 않는다.
+5. stable high-level SDK에는 native review method가 없으므로 Step 8 전에는 기존
+   read-only review를 유지한다. private client나 generated `review/start`, 직접
+   App Server protocol 구현을 필수 의존성으로 사용하지 않는다.
+6. credential, account identifier, thread identifier, prompt와 response 본문을
+   telemetry나 committed artifact에 기록하지 않는다.
+
+## 근거
+
+Windows 11, Python 3.12.13에서 SDK의 saved login 재사용, model list, thread
+start/run/continue, 새 client에서 resume, read-only write 차단, `deny_all`, invalid
+resume 뒤 같은 client 복구, caller timeout 뒤 interrupt가 통과했다. SDK와 runtime은
+같은 stable version으로 설치됐다.
+
+반면 native timeout과 high-level native review는 없었다. 아주 짧은 timeout에서는
+turn completion과 interrupt가 경합했고, client 종료 전 Windows 임시 디렉터리
+정리도 file lock에 실패할 수 있었다. Ubuntu/macOS, headless CI와 장시간 안정성은
+아직 검증하지 않았다.
+
+## 전환 전제
+
+- Step 6 adapter가 기존 환경 상속 최소화, worktree owner/base pin, v1/v2 원형과
+  serial list-order를 그대로 보존한다.
+- SDK/exec가 같은 acceptance, scope, diff, CI gate를 거치고 fallback 원인만
+  비민감 structured result에 남긴다.
+- Ubuntu/macOS/Windows와 headless CI에서 package install, auth boundary, sandbox,
+  timeout/cleanup을 검증한다.
+- Step 10의 EVAL-V1과 EVAL-SAFETY hard gate가 100%이고 quality gate가 회귀하지
+  않는다.
+
+## Fallback과 rollback
+
+SDK import 또는 version pin, bundled runtime 시작, 인증, model capability,
+sandbox/approval mapping, timeout/interrupt, typed output 처리 중 하나라도 실패하면
+그 task는 현재 `codex exec` 경로에서 같은 gate로 다시 실행한다. 무조건 retry하지
+않고 기존 retry 상한을 적용한다.
+
+fallback 자체가 실패하거나 safety/v1 gate를 우회하면 새 task와 merge를 중단하고
+진행 중 issue/branch/worktree/state를 보존한다. SDK flag를 비활성화한 뒤
+`COMPATIBILITY.md`의 마지막 검증된 exec 경로와 rollback 절차로 복구한다. force
+push, hard reset과 사용자 worktree 자동 삭제는 사용하지 않는다.
+
+## 결과
+
+- Step 5는 production runner를 수정하지 않는다.
+- Step 6은 SDK와 exec를 공통 contract 뒤에 둘 수 있지만 SDK 기본 전환은 별도
+  검증과 승인이 필요하다.
+- Step 8 native review adapter는 이번 결정과 분리한다.

--- a/issues/harness-v2-modernization/issue-1.md
+++ b/issues/harness-v2-modernization/issue-1.md
@@ -1,0 +1,34 @@
+# Issue 1: 외부 Codex read-only review 실행 차단
+
+## 상태
+
+- Phase: `harness-v2-modernization`
+- Step: `5 sdk-spike`
+- GitHub Issue: `#18`
+- 분류: 외부 review gate 실행 정책 차단
+
+## 현상
+
+외부 Codex read-only review를 실행하려 했으나 비공개 저장소 내용의 외부 전송에는 별도의 명시적 승인이 필요하다는 정책으로 차단되었다. 최초 요청 뒤 계약 파일과 변경 파일만 명시한 축소 재시도 1회도 같은 이유로 차단되었다.
+
+코드 또는 문서에 대한 review finding은 생성되지 않았다.
+
+## 영향
+
+- 구현과 로컬 자동 검증은 통과했다.
+- 외부 review gate가 완료되지 않아 Step 5는 `blocked`로 유지한다.
+- PR은 Draft로 유지하며 Ready 전환과 병합을 하지 않는다.
+
+## 복구 조건
+
+사용자가 비공개 저장소의 지정된 계약 파일과 변경 파일을 외부 Codex read-only review에 전송하도록 명시적으로 승인한 뒤 review를 다시 실행한다. finding이 없거나 허용된 retry 범위에서 모두 해소되면 Step 5를 `completed`로 갱신하고 PR Ready 전환을 검토한다.
+
+## 검증 근거
+
+- SDK spike targeted tests: 통과
+- 전체 `scripts` pytest: 통과
+- compileall: 통과
+- template doctor: 통과
+- phase docs-check: 통과
+- `git diff --check`: 통과
+- manual/final stage: 템플릿의 미설정 `test`, `build` 명령 때문에 실패하며 SDK spike 회귀와 무관

--- a/phases/harness-v2-modernization/COMPATIBILITY.md
+++ b/phases/harness-v2-modernization/COMPATIBILITY.md
@@ -50,6 +50,26 @@
 - 실패를 성공으로 바꾸는 무조건 retry는 허용하지 않는다. retry 상한 뒤에는
   `error` 또는 `blocked`로 멈춘다.
 
+## Python SDK spike 결정 (#18)
+
+SDK-CONDITIONAL-GO-0.147.0-EXEC-FALLBACK
+
+- `openai-codex==0.147.0`과 matching `openai-codex-cli-bin==0.147.0`의 Windows
+  live spike는 auth, model list, thread start/run/continue/resume, read-only sandbox,
+  `deny_all`, typed 오류 복구와 caller timeout 뒤 interrupt를 통과했다.
+- 이 결과는 Step 6의 opt-in adapter 설계를 허용하는 조건부 GO다. production
+  기본값은 계속 `codex exec`이며 SDK가 없거나 version/runtime/auth/model/sandbox/
+  approval/timeout/interrupt/output 검증에 실패하면 같은 gate를 유지한 채 exec로
+  fallback한다.
+- stable high-level SDK에는 native turn timeout과 native review method가 없다.
+  timeout은 caller deadline과 interrupt/terminal wait/client close로 감싸고,
+  native review는 Step 8까지 기존 read-only review 경로를 유지한다.
+- private/generated App Server review API를 필수 의존성으로 사용하지 않는다.
+  Ubuntu/macOS, headless CI와 장시간 안정성 검증 전에는 SDK feature flag를 기본으로
+  켜지 않는다.
+- 상세 환경, 실패 분류와 비민감 결과는 `SDK_SPIKE.md`와
+  `SDK_SPIKE_RESULTS.json`을 따른다.
+
 ## rollback trigger
 
 다음 중 하나면 v2 경로의 배포·기본 전환을 중단하고 마지막 검증된 v1 경로로

--- a/phases/harness-v2-modernization/SDK_SPIKE.md
+++ b/phases/harness-v2-modernization/SDK_SPIKE.md
@@ -1,0 +1,155 @@
+# Python Codex SDK spike 결과
+
+- 관련 이슈: [#18](https://github.com/vanilalatte03/codex-project-ops-template/issues/18)
+- 기준 commit: `75a5b3e7c51c9c464da3b4e26a238b309fac003b`
+- 기록일: 2026-09-06
+- 결정: **조건부 GO**. Step 6에서 opt-in adapter를 설계할 근거는 확보했지만,
+  현재 production 기본 경로는 계속 `codex exec`로 유지한다.
+
+## 공식 근거
+
+- [Codex SDK](https://developers.openai.com/codex/sdk)는 Python SDK를 stable release로
+  명시하며 Python 3.10+, pinned Codex CLI runtime, thread start/run/resume와 sandbox
+  preset을 설명한다.
+- [Codex App Server](https://developers.openai.com/codex/app-server)는 custom client가
+  인증, 대화 이력, 승인과 streaming event를 직접 다룰 때의 경계다. 자동화/CI에는
+  SDK 사용을 권한다.
+- [Non-interactive mode](https://learn.chatgpt.com/codex/non-interactive-mode)는
+  `codex exec`의 JSONL, sandbox, saved CLI auth 재사용과 `exec resume` 계약을
+  설명한다.
+- 공식 `openai/codex` 저장소의
+  [Python API reference](https://github.com/openai/codex/blob/main/sdk/python/docs/api-reference.md)와
+  [FAQ](https://github.com/openai/codex/blob/main/sdk/python/docs/faq.md)를 package
+  surface 대조에 사용했다.
+
+## 고정 환경
+
+| 항목 | 값 |
+| --- | --- |
+| OS | Windows 11 `10.0.26200` |
+| Python | uv managed CPython `3.12.13` |
+| SDK | `openai-codex==0.147.0` stable |
+| SDK runtime | `openai-codex-cli-bin==0.147.0` |
+| 기존 CLI | `codex-cli 0.146.0` (`@openai/codex==0.146.0`) |
+| model | `gpt-5.6-terra` |
+| sandbox / approval | `read-only`; `deny_all` 또는 interrupt probe의 `auto_review` |
+| cwd | probe마다 새 빈 임시 디렉터리 |
+
+`openai-codex` 파일 크기는 474,769 byte, pinned runtime은 370,445,518 byte였다.
+기존 global npm CLI 디렉터리는 429,301,280 byte였다. 서로 다른 package layout과
+cache를 잰 값이므로 설치 footprint의 대략적인 관찰값이며 직접 성능 비교값은 아니다.
+
+## 재현 명령
+
+offline surface probe와 live probe는 사용자 전역 Python 또는 Codex 설정을 바꾸지
+않는 uv isolated environment에서 실행한다.
+
+```powershell
+uv run --isolated --no-project --with openai-codex==0.147.0 `
+  python -X utf8 scripts/sdk_spike.py
+
+uv run --isolated --no-project --with openai-codex==0.147.0 `
+  python -X utf8 scripts/sdk_spike.py --live `
+  --model gpt-5.6-terra --timeout-seconds 1
+```
+
+두 번째 명령은 기존 Codex 인증을 읽고 모델 호출을 수행한다. stdout과
+[`SDK_SPIKE_RESULTS.json`](SDK_SPIKE_RESULTS.json)에는 boolean, duration, error
+class만 남기며 credential, 계정 식별자, thread ID, prompt와 응답 본문은 남기지
+않는다. live 실행은 지속성 확인용 thread를 새 SDK client에서 resume한 뒤 archive한다.
+
+기존 CLI 비교 실행은 빈 비-Git 디렉터리라서 명시적으로 repository 검사를
+건너뛰었다.
+
+```powershell
+codex exec --json --skip-git-repo-check -s read-only -C <empty-temp-dir> `
+  "Reply with exactly EXEC_OK and do not use tools."
+```
+
+실제 결과는 exit `0`, JSONL event 5개, wall time `17.13s`였다. 처음
+`--skip-git-repo-check` 없이 실행한 결과는 의도한 안전 precondition에 따라 exit
+`1`과 `Not inside a trusted directory`로 중단됐다.
+
+## capability 결과
+
+| capability | 기대 결과 | 실제 결과 | 판정 |
+| --- | --- | --- | --- |
+| stable package / runtime pin | 같은 버전의 SDK와 runtime 설치 | 둘 다 `0.147.0` | 가능 |
+| Windows 인증 | 기존 Codex login 재사용, 값 비노출 | account 존재 여부만 `true` | 가능 |
+| thread start / run | 지정 model로 terminal completion | exact sentinel, `completed` | 가능 |
+| 같은 thread 연속 run | 두 번째 turn 완료 | exact sentinel, `completed` | 가능 |
+| client 재시작 후 resume | 같은 thread 재개 | same identifier 확인 후 sentinel 완료 | 가능 |
+| model capability | model list에서 지정 model 확인 | 5개 중 `gpt-5.6-terra` 존재 | 가능 |
+| read-only sandbox | 쓰기 요청이 파일을 만들지 않음 | marker 없음 | 가능 |
+| approval | `deny_all`에서 사용자 입력 없이 종료 | 사람 개입 0회 | 가능 |
+| 오류 복구 | invalid resume 뒤 같은 client 재사용 | `InvalidRequestError` 뒤 새 turn 완료 | 가능 |
+| timeout | turn 자체 timeout 인자 | `Thread.run`에 timeout 없음 | 불가능 |
+| interrupt | active turn 중단 | caller 1초 timeout 뒤 `interrupted` | 가능 |
+| native review | stable high-level review method | `Codex`/`Thread`에 없음 | 불가능 |
+
+첫 interrupt 시도는 10ms timeout 뒤 turn이 이미 끝나 `InvalidRequestError: no active
+turn` race가 발생했고, client 종료 전 임시 디렉터리 정리에서 Windows file lock도
+관찰됐다. 30초 shell wait로 active turn을 보장하고 client를 먼저 닫은 재현에서는
+1초 caller timeout, `TurnHandle.interrupt()`, terminal `interrupted`가 통과했다.
+adapter는 interrupt를 idempotent completion으로 취급하고 client 종료 뒤 임시 파일을
+정리해야 한다.
+
+## `codex exec` 비교
+
+| 관점 | Python SDK 0.147.0 | 기존 `codex exec` 0.146.0 |
+| --- | --- | --- |
+| 설치 | Python 3.10+, `openai-codex`와 pinned binary runtime | Node/npm 또는 설치된 CLI binary |
+| runtime | bundled app-server subprocess와 JSON-RPC | CLI subprocess 한 번과 JSONL stdout |
+| 인증 | Windows saved Codex login 재사용 확인 | saved CLI auth 재사용 확인 |
+| 출력 | typed `TurnResult`, items, usage, typed exception | JSONL event와 exit code/stderr 직접 parsing |
+| thread | object로 연속 run, ID resume, read/list | `codex exec resume`와 persisted session |
+| sandbox/approval | enum preset과 turn override; `deny_all`, `auto_review` | CLI flag/config를 subprocess 인자로 전달 |
+| timeout/interrupt | native timeout 없음; caller timeout + handle interrupt 필요 | Harness가 subprocess timeout/termination 담당 |
+| review | stable high-level native review 없음; read-only prompt는 가능 | `codex review` 또는 현재 read-only `codex exec` gate |
+| 테스트 난이도 | typed API unit test는 쉽지만 live auth/app-server test 필요 | subprocess/JSONL fixture와 exit-code test 필요 |
+| 주요 위험 | app-server lifecycle, version pin, cleanup/race, API surface 변화 | 문자열 command, JSONL drift, process cleanup, resume ID 관리 |
+
+SDK의 `CodexConfig.experimental_api` 기본값은 `true`로 관찰됐다. 이 값만으로 core
+thread API 전체가 실험적이라고 단정하지는 않지만, Step 6 adapter가 private client나
+generated `review/start`를 직접 사용해서는 안 된다는 추가 경계로 본다.
+
+## 가능 / 불가능 / 미검증
+
+가능:
+
+- Windows saved login으로 stable SDK thread start/run/continue/resume
+- `read-only` sandbox와 `deny_all` 무인 failure behavior
+- typed invalid-request 분류 뒤 같은 client 복구
+- caller-managed timeout과 active turn interrupt
+
+현재 stable high-level surface에서 불가능:
+
+- `Thread.run(..., timeout=...)` 형태의 native turn timeout
+- `Codex.review(...)` 또는 `Thread.review(...)` 형태의 native review
+
+미검증:
+
+- Ubuntu/macOS의 인증 저장소와 sandbox 동작
+- headless CI credential provisioning, proxy와 enterprise policy
+- `workspace-write`/`full-access`, 사용자 승인 callback, concurrent turn 부하
+- SDK usage/token과 기존 JSONL의 장기 schema 호환, 장시간 app-server 안정성
+
+## 결론과 Step 6 전환 전제
+
+SDK-CONDITIONAL-GO-0.147.0-EXEC-FALLBACK
+
+Step 6은 다음 전제를 모두 지키는 opt-in adapter만 설계할 수 있다.
+
+1. `openai-codex==0.147.0`과 matching runtime을 고정하고 기본 runner는 바꾸지 않는다.
+2. SDK가 없거나 version/auth/model/sandbox/approval/timeout/interrupt/output 중 하나라도
+   검증에 실패하면 현재 `codex exec` 경로로 fail-closed fallback한다.
+3. caller timeout 뒤 interrupt, terminal wait, client close 순서를 지키고 이미 끝난
+   turn의 interrupt race는 성공 완료와 구분해 idempotent하게 처리한다.
+4. native review는 이번 GO에 포함하지 않는다. Step 8까지 기존 read-only review를
+   유지하며 private/generated app-server review API에 의존하지 않는다.
+5. Linux/macOS와 headless CI를 검증하고 EVAL-V1/EVAL-SAFETY hard gate를 통과하기
+   전에는 feature flag 기본값을 SDK로 바꾸지 않는다.
+
+위 전제 중 하나가 깨지면 SDK adapter를 비활성화하고
+[`COMPATIBILITY.md`](COMPATIBILITY.md)의 `codex exec` fallback과 rollback 절차를
+적용한다.

--- a/phases/harness-v2-modernization/SDK_SPIKE_RESULTS.json
+++ b/phases/harness-v2-modernization/SDK_SPIKE_RESULTS.json
@@ -1,0 +1,78 @@
+{
+  "capabilities": {
+    "appServerTransport": true,
+    "approvalModes": [
+      "auto_review",
+      "deny_all"
+    ],
+    "experimentalApiDefault": true,
+    "modelList": true,
+    "nativeReviewHighLevel": false,
+    "nativeTurnTimeoutParameter": false,
+    "sandboxPresets": [
+      "full-access",
+      "read-only",
+      "workspace-write"
+    ],
+    "threadPersistenceRead": true,
+    "threadResume": true,
+    "threadRun": true,
+    "threadStart": true,
+    "turnInterrupt": true
+  },
+  "environment": {
+    "os": "Windows-11-10.0.26200-SP0",
+    "python": "3.12.13"
+  },
+  "live": {
+    "errorRecovery": {
+      "intentionalFailure": {
+        "category": "invalid-request",
+        "errorClass": "InvalidRequestError",
+        "status": "failed"
+      },
+      "sameClientRecovered": true,
+      "status": "passed"
+    },
+    "sandboxAndApproval": {
+      "approvalMode": "deny_all",
+      "humanInterventionCount": 0,
+      "readOnlyWriteBlocked": true,
+      "status": "passed",
+      "turnReachedTerminalState": true
+    },
+    "status": "completed",
+    "threadLifecycle": {
+      "authenticated": true,
+      "continue": true,
+      "model": "gpt-5.6-terra",
+      "modelAdvertised": true,
+      "modelCount": 5,
+      "resumeAfterClientRestart": true,
+      "start": true,
+      "status": "passed",
+      "wallTimeSeconds": {
+        "continue": 3.891,
+        "resume": 5.453,
+        "start": 6.047
+      }
+    },
+    "timeoutAndInterrupt": {
+      "callerTimeoutTriggered": true,
+      "interruptSent": true,
+      "sdkNativeTimeoutParameter": false,
+      "status": "passed",
+      "terminalStatus": "interrupted"
+    }
+  },
+  "package": {
+    "runtime": "openai-codex-cli-bin==0.147.0",
+    "sdk": "openai-codex==0.147.0"
+  },
+  "privacy": {
+    "credentialMaterialStored": false,
+    "privateThreadIdentifierStored": false,
+    "responseContentStored": false
+  },
+  "schemaVersion": 1
+}

--- a/phases/harness-v2-modernization/docs-checks.json
+++ b/phases/harness-v2-modernization/docs-checks.json
@@ -59,6 +59,16 @@
       "name": "safe cleanup ownership gate",
       "paths": ["docs/WORKTREE_LIFECYCLE.md"],
       "pattern": "status가 `merged`이고 owner/task/path/branch가 일치"
+    },
+    {
+      "name": "Python SDK conditional decision",
+      "paths": ["docs/adr/0005-python-codex-sdk-spike.md"],
+      "pattern": "결정 식별자: SDK-CONDITIONAL-GO-0\\.147\\.0-EXEC-FALLBACK"
+    },
+    {
+      "name": "Python SDK exec fallback contract",
+      "paths": ["phases/harness-v2-modernization/COMPATIBILITY.md"],
+      "pattern": "SDK-CONDITIONAL-GO-0\\.147\\.0-EXEC-FALLBACK"
     }
   ],
   "finalRequired": [],

--- a/phases/harness-v2-modernization/index.json
+++ b/phases/harness-v2-modernization/index.json
@@ -37,7 +37,13 @@
       "completed_at": "2026-09-04T21:51:08+0900",
       "summary": "task별 owner marker와 pinned base SHA worktree lifecycle을 도입하고 primary 불변·직렬 autopilot·실패 보존·safe cleanup 및 Windows/stale 격리 검증을 추가했다."
     },
-    { "step": 5, "name": "sdk-spike", "status": "pending" },
+    {
+      "step": 5,
+      "name": "sdk-spike",
+      "status": "blocked",
+      "blocked_at": "2026-09-06T19:20:37+0900",
+      "blocked_reason": "외부 Codex read-only review가 비공개 저장소 egress 승인 정책으로 최초 1회와 축소 재시도 1회 모두 차단되어 review gate를 완료하지 못했다. 구현 및 로컬 검증은 통과했다."
+    },
     { "step": 6, "name": "runner-adapter", "status": "pending" },
     { "step": 7, "name": "resumable-telemetry", "status": "pending" },
     { "step": 8, "name": "risk-based-review", "status": "pending" },

--- a/scripts/sdk_spike.py
+++ b/scripts/sdk_spike.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Probe the pinned Python Codex SDK without storing private thread content."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import importlib.metadata
+import inspect
+import json
+import platform
+import re
+import sys
+import tempfile
+import time
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable
+
+
+SDK_DISTRIBUTION = "openai-codex"
+RUNTIME_DISTRIBUTION = "openai-codex-cli-bin"
+PINNED_SDK_VERSION = "0.147.0"
+DEFAULT_MODEL = "gpt-5.6-terra"
+
+_SENSITIVE_KEY_RE = re.compile(
+    r"(?:credential|token|password|api[_-]?key|thread[_-]?id|response[_-]?(?:text|body)|prompt)",
+    re.IGNORECASE,
+)
+_SENSITIVE_VALUE_RES = (
+    re.compile(r"\bsk-[A-Za-z0-9_-]{8,}"),
+    re.compile(r"\b(?:thread|thr)_[A-Za-z0-9_-]+", re.IGNORECASE),
+    re.compile(r"[A-Za-z]:\\Users\\[^\\\s]+", re.IGNORECASE),
+    re.compile(r"/(?:Users|home)/[^/\s]+", re.IGNORECASE),
+)
+
+
+class SpikeError(RuntimeError):
+    """Raised when the probe cannot produce a safe, comparable report."""
+
+
+def _version(distribution: str) -> str:
+    return importlib.metadata.version(distribution)
+
+
+def require_pinned_version(actual: str) -> None:
+    if actual != PINNED_SDK_VERSION:
+        raise SpikeError(
+            f"expected {SDK_DISTRIBUTION}=={PINNED_SDK_VERSION}, got {actual}"
+        )
+
+
+def classify_exception(exc: BaseException) -> dict[str, str]:
+    """Return only a stable error class/category, never the exception message."""
+    name = type(exc).__name__
+    lowered = name.lower()
+    if "auth" in lowered or "login" in lowered:
+        category = "authentication"
+    elif "timeout" in lowered:
+        category = "timeout"
+    elif "transport" in lowered or "closed" in lowered:
+        category = "transport"
+    elif "invalid" in lowered or "notfound" in lowered or "not_found" in lowered:
+        category = "invalid-request"
+    elif "retry" in lowered or "busy" in lowered or "overload" in lowered:
+        category = "retryable-runtime"
+    else:
+        category = "runtime"
+    return {"status": "failed", "category": category, "errorClass": name}
+
+
+def _method_has_parameter(target: Callable[..., Any], parameter: str) -> bool:
+    return parameter in inspect.signature(target).parameters
+
+
+def static_capabilities(sdk: ModuleType) -> dict[str, Any]:
+    codex = sdk.Codex
+    thread = sdk.Thread
+    turn_handle = sdk.TurnHandle
+    config_signature = inspect.signature(sdk.CodexConfig)
+    experimental_default = config_signature.parameters["experimental_api"].default
+    return {
+        "threadStart": hasattr(codex, "thread_start"),
+        "threadRun": hasattr(thread, "run"),
+        "threadResume": hasattr(codex, "thread_resume"),
+        "threadPersistenceRead": hasattr(thread, "read"),
+        "sandboxPresets": sorted(item.value for item in sdk.Sandbox),
+        "approvalModes": sorted(item.value for item in sdk.ApprovalMode),
+        "nativeTurnTimeoutParameter": _method_has_parameter(thread.run, "timeout"),
+        "turnInterrupt": hasattr(turn_handle, "interrupt"),
+        "modelList": hasattr(codex, "models"),
+        "nativeReviewHighLevel": hasattr(codex, "review") or hasattr(thread, "review"),
+        "appServerTransport": True,
+        "experimentalApiDefault": experimental_default,
+    }
+
+
+def build_static_report() -> tuple[dict[str, Any], ModuleType]:
+    sdk_version = _version(SDK_DISTRIBUTION)
+    require_pinned_version(sdk_version)
+    runtime_version = _version(RUNTIME_DISTRIBUTION)
+    import openai_codex as sdk
+
+    report = {
+        "schemaVersion": 1,
+        "package": {
+            "sdk": f"{SDK_DISTRIBUTION}=={sdk_version}",
+            "runtime": f"{RUNTIME_DISTRIBUTION}=={runtime_version}",
+        },
+        "environment": {
+            "os": platform.platform(),
+            "python": platform.python_version(),
+        },
+        "capabilities": static_capabilities(sdk),
+        "privacy": {
+            "credentialMaterialStored": False,
+            "privateThreadIdentifierStored": False,
+            "responseContentStored": False,
+        },
+        "live": {"status": "not-run", "reason": "pass --live to run authenticated probes"},
+    }
+    return report, sdk
+
+
+def _timed(action: Callable[[], Any]) -> tuple[Any, float]:
+    started = time.monotonic()
+    value = action()
+    return value, round(time.monotonic() - started, 3)
+
+
+def _completed(result: Any) -> bool:
+    return str(getattr(result, "status", "")).lower().endswith("completed")
+
+
+def _run_text_turn(thread: Any, expected: str) -> tuple[bool, float]:
+    result, elapsed = _timed(
+        lambda: thread.run(f"Reply with exactly {expected} and do not use tools.")
+    )
+    return _completed(result) and result.final_response.strip() == expected, elapsed
+
+
+def _probe_thread_lifecycle(sdk: ModuleType, cwd: str, model: str) -> dict[str, Any]:
+    thread_identifier: str | None = None
+    try:
+        with sdk.Codex() as codex:
+            account = codex.account()
+            models = codex.models().data
+            model_ids = {item.model for item in models}
+            thread = codex.thread_start(
+                cwd=cwd,
+                model=model,
+                sandbox=sdk.Sandbox.read_only,
+                approval_mode=sdk.ApprovalMode.deny_all,
+            )
+            thread_identifier = thread.id
+            started, start_seconds = _run_text_turn(thread, "SDK_START_OK")
+            continued, continue_seconds = _run_text_turn(thread, "SDK_CONTINUE_OK")
+
+        with sdk.Codex() as resumed_codex:
+            resumed = resumed_codex.thread_resume(
+                thread_identifier,
+                cwd=cwd,
+                model=model,
+                sandbox=sdk.Sandbox.read_only,
+                approval_mode=sdk.ApprovalMode.deny_all,
+            )
+            resumed_ok, resume_seconds = _run_text_turn(resumed, "SDK_RESUME_OK")
+            same_identifier = resumed.id == thread_identifier
+            resumed_codex.thread_archive(thread_identifier)
+
+        return {
+            "status": "passed",
+            "authenticated": getattr(account, "account", None) is not None,
+            "model": model,
+            "modelAdvertised": model in model_ids,
+            "modelCount": len(models),
+            "start": started,
+            "continue": continued,
+            "resumeAfterClientRestart": resumed_ok and same_identifier,
+            "wallTimeSeconds": {
+                "start": start_seconds,
+                "continue": continue_seconds,
+                "resume": resume_seconds,
+            },
+        }
+    except Exception as exc:  # the safe report intentionally omits raw messages
+        return classify_exception(exc)
+
+
+def _probe_sandbox_and_approval(sdk: ModuleType, cwd: str, model: str) -> dict[str, Any]:
+    marker = Path(cwd) / "sandbox-marker.txt"
+    try:
+        with sdk.Codex() as codex:
+            thread = codex.thread_start(
+                cwd=cwd,
+                model=model,
+                sandbox=sdk.Sandbox.read_only,
+                approval_mode=sdk.ApprovalMode.deny_all,
+                ephemeral=True,
+            )
+            result = thread.run(
+                "Use apply_patch to create sandbox-marker.txt containing "
+                "SDK_SANDBOX_MARKER. Do not merely describe it."
+            )
+        return {
+            "status": "passed" if not marker.exists() else "failed",
+            "turnReachedTerminalState": str(getattr(result, "status", ""))
+            .lower()
+            .endswith(("completed", "failed", "interrupted")),
+            "readOnlyWriteBlocked": not marker.exists(),
+            "approvalMode": "deny_all",
+            "humanInterventionCount": 0,
+        }
+    except Exception as exc:
+        return classify_exception(exc)
+
+
+def _probe_error_recovery(sdk: ModuleType, cwd: str, model: str) -> dict[str, Any]:
+    intentional_error: dict[str, str] | None = None
+    recovered = False
+    try:
+        with sdk.Codex() as codex:
+            try:
+                codex.thread_resume(
+                    "00000000-0000-0000-0000-000000000000",
+                    cwd=cwd,
+                    sandbox=sdk.Sandbox.read_only,
+                    approval_mode=sdk.ApprovalMode.deny_all,
+                )
+            except Exception as exc:
+                intentional_error = classify_exception(exc)
+            thread = codex.thread_start(
+                cwd=cwd,
+                model=model,
+                sandbox=sdk.Sandbox.read_only,
+                approval_mode=sdk.ApprovalMode.deny_all,
+                ephemeral=True,
+            )
+            recovered, _ = _run_text_turn(thread, "SDK_RECOVERY_OK")
+        return {
+            "status": "passed" if intentional_error and recovered else "failed",
+            "intentionalFailure": intentional_error,
+            "sameClientRecovered": recovered,
+        }
+    except Exception as exc:
+        return classify_exception(exc)
+
+
+def _probe_timeout_and_interrupt(
+    sdk: ModuleType,
+    cwd: str,
+    model: str,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    command = "Start-Sleep -Seconds 30" if sys.platform == "win32" else "sleep 30"
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    codex = None
+    timed_out = False
+    interrupted = False
+    terminal = "unknown"
+    try:
+        codex = sdk.Codex()
+        thread = codex.thread_start(
+            cwd=cwd,
+            model=model,
+            sandbox=sdk.Sandbox.read_only,
+            approval_mode=sdk.ApprovalMode.auto_review,
+            ephemeral=True,
+        )
+        handle = thread.turn(
+            f"Run this exact shell command before replying: {command}. Then reply DONE."
+        )
+        future = executor.submit(handle.run)
+        try:
+            future.result(timeout=timeout_seconds)
+        except concurrent.futures.TimeoutError:
+            timed_out = True
+            handle.interrupt()
+            interrupted = True
+        result = future.result(timeout=30)
+        terminal = str(getattr(result, "status", "unknown"))
+        passed = timed_out and interrupted and terminal.lower().endswith("interrupted")
+        return {
+            "status": "passed" if passed else "failed",
+            "sdkNativeTimeoutParameter": False,
+            "callerTimeoutTriggered": timed_out,
+            "interruptSent": interrupted,
+            "terminalStatus": terminal.split(".")[-1].lower(),
+        }
+    except Exception as exc:
+        return classify_exception(exc)
+    finally:
+        executor.shutdown(wait=True)
+        if codex is not None:
+            codex.close()
+
+
+def run_live_probes(
+    report: dict[str, Any],
+    sdk: ModuleType,
+    *,
+    model: str,
+    timeout_seconds: float,
+) -> None:
+    with tempfile.TemporaryDirectory(prefix="codex-sdk-spike-") as cwd:
+        report["live"] = {
+            "status": "completed",
+            "threadLifecycle": _probe_thread_lifecycle(sdk, cwd, model),
+            "sandboxAndApproval": _probe_sandbox_and_approval(sdk, cwd, model),
+            "errorRecovery": _probe_error_recovery(sdk, cwd, model),
+            "timeoutAndInterrupt": _probe_timeout_and_interrupt(
+                sdk, cwd, model, timeout_seconds
+            ),
+        }
+
+
+def assert_safe_report(value: Any, *, path: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if _SENSITIVE_KEY_RE.search(str(key)) and child not in (False, None):
+                raise SpikeError(f"unsafe report key at {path}.{key}")
+            assert_safe_report(child, path=f"{path}.{key}")
+        return
+    if isinstance(value, list):
+        for index, child in enumerate(value):
+            assert_safe_report(child, path=f"{path}[{index}]")
+        return
+    if isinstance(value, str):
+        if any(pattern.search(value) for pattern in _SENSITIVE_VALUE_RES):
+            raise SpikeError(f"unsafe report value at {path}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--live", action="store_true", help="Run authenticated live probes")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Model used by live probes")
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=1.0,
+        help="Caller timeout before interrupting the long-running probe turn",
+    )
+    parser.add_argument("--output", type=Path, help="Write the sanitized JSON report")
+    args = parser.parse_args(argv)
+    if args.timeout_seconds <= 0:
+        parser.error("--timeout-seconds must be greater than 0")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report, sdk = build_static_report()
+        if args.live:
+            run_live_probes(
+                report,
+                sdk,
+                model=args.model,
+                timeout_seconds=args.timeout_seconds,
+            )
+        assert_safe_report(report)
+    except (SpikeError, importlib.metadata.PackageNotFoundError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"ERROR: {type(exc).__name__}", file=sys.stderr)
+        return 1
+
+    encoded = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(encoded, encoding="utf-8")
+    else:
+        print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_sdk_spike.py
+++ b/scripts/tests/test_sdk_spike.py
@@ -1,0 +1,138 @@
+import json
+from enum import Enum
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import sdk_spike
+
+
+def test_require_pinned_version_rejects_drift():
+    with pytest.raises(sdk_spike.SpikeError, match="expected openai-codex==0.147.0"):
+        sdk_spike.require_pinned_version("0.148.0")
+
+
+def test_classify_exception_does_not_store_message():
+    failure = sdk_spike.classify_exception(
+        RuntimeError("sk-secret-value thread_private C:\\Users\\private")
+    )
+
+    assert failure == {
+        "status": "failed",
+        "category": "runtime",
+        "errorClass": "RuntimeError",
+    }
+
+
+def test_static_capabilities_separates_timeout_interrupt_and_native_review():
+    class Approval(Enum):
+        deny_all = "deny_all"
+        auto_review = "auto_review"
+
+    class Sandbox(Enum):
+        read_only = "read-only"
+        workspace_write = "workspace-write"
+
+    class CodexConfig:
+        def __init__(self, experimental_api: bool = True):
+            pass
+
+    class Codex:
+        def thread_start(self):
+            pass
+
+        def thread_resume(self):
+            pass
+
+        def models(self):
+            pass
+
+    class Thread:
+        def run(self):
+            pass
+
+        def read(self):
+            pass
+
+    class TurnHandle:
+        def interrupt(self):
+            pass
+
+    sdk = SimpleNamespace(
+        ApprovalMode=Approval,
+        Sandbox=Sandbox,
+        CodexConfig=CodexConfig,
+        Codex=Codex,
+        Thread=Thread,
+        TurnHandle=TurnHandle,
+    )
+
+    capabilities = sdk_spike.static_capabilities(sdk)
+
+    assert capabilities["threadStart"] is True
+    assert capabilities["threadResume"] is True
+    assert capabilities["nativeTurnTimeoutParameter"] is False
+    assert capabilities["turnInterrupt"] is True
+    assert capabilities["nativeReviewHighLevel"] is False
+    assert capabilities["experimentalApiDefault"] is True
+
+
+@pytest.mark.parametrize(
+    "unsafe",
+    [
+        {"threadId": "private"},
+        {"prompt": "harmless-looking"},
+        {"value": "sk-secret-value"},
+        {"value": "C:\\Users\\private\\file.txt"},
+    ],
+)
+def test_assert_safe_report_rejects_sensitive_keys_and_values(unsafe):
+    with pytest.raises(sdk_spike.SpikeError, match="unsafe report"):
+        sdk_spike.assert_safe_report(unsafe)
+
+
+def test_assert_safe_report_accepts_boolean_privacy_attestations():
+    sdk_spike.assert_safe_report(
+        {
+            "credentialMaterialStored": False,
+            "privateThreadIdentifierStored": False,
+            "responseContentStored": False,
+        }
+    )
+
+
+def test_parse_args_defaults_to_offline_probe():
+    args = sdk_spike.parse_args([])
+
+    assert args.live is False
+    assert args.model == "gpt-5.6-terra"
+    assert args.timeout_seconds == 1.0
+
+
+def test_committed_result_is_sanitized_and_matches_pin():
+    result_path = (
+        Path(__file__).resolve().parents[2]
+        / "phases"
+        / "harness-v2-modernization"
+        / "SDK_SPIKE_RESULTS.json"
+    )
+    report = json.loads(result_path.read_text(encoding="utf-8"))
+
+    sdk_spike.assert_safe_report(report)
+    assert report["package"]["sdk"] == "openai-codex==0.147.0"
+    assert report["package"]["runtime"] == "openai-codex-cli-bin==0.147.0"
+    assert report["live"]["threadLifecycle"]["resumeAfterClientRestart"] is True
+    assert report["live"]["timeoutAndInterrupt"]["terminalStatus"] == "interrupted"
+
+
+def test_main_redacts_unexpected_error_message(monkeypatch, capsys):
+    def fail():
+        raise RuntimeError("sk-secret-value C:\\Users\\private")
+
+    monkeypatch.setattr(sdk_spike, "build_static_report", fail)
+
+    assert sdk_spike.main([]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "ERROR: RuntimeError\n"


### PR DESCRIPTION
Closes #18

## 작업 내용
- stable Python Codex SDK `openai-codex==0.147.0`을 Windows에서 고정해 thread 시작/연속 실행/resume, 저장 인증 재사용, read-only sandbox, deny-all approval, 오류 복구, timeout 후 interrupt를 검증했습니다.
- SDK와 기존 `codex exec`의 자동화 표면을 비교하고, 실측 결과를 재현 가능한 스크립트·sanitized JSON·문서로 남겼습니다.
- ADR-0005에서 향후 opt-in runner adapter에 한정한 **조건부 GO**를 결정했습니다.
- production 기본 경로는 계속 `codex exec`이며, adapter 전환 전 회귀 검증과 즉시 rollback 가능한 exec fallback을 필수 조건으로 고정했습니다.

## 주요 결과
- SDK start/run/continue/resume/auth/sandbox/approval/error recovery/interrupt: 통과
- 고수준 SDK native timeout parameter: 없음
- 고수준 SDK native review API: 없음
- Windows caller timeout 뒤 `interrupt()`: 통과
- 기존 CLI 비교: non-git temp cwd는 `--skip-git-repo-check` 없이 실패, 옵션 추가 시 JSONL 실행 통과
- 민감정보, account/thread identifier, 실제 사용자 경로는 결과 artifact에서 제외했습니다.

## 검증
- `uv run --isolated --no-project --with pytest python -X utf8 -m pytest scripts/tests/test_sdk_spike.py -q` — 11 passed
- `uv run --isolated --no-project --with pytest python -X utf8 -m pytest scripts` — 233 passed
- `uv run --isolated --no-project python -X utf8 -m compileall -q scripts` — passed
- `uv run --isolated --no-project python -X utf8 scripts/doctor.py --template` — Template readiness ok, ADR 5개
- `uv run --isolated --no-project python -X utf8 scripts/checks.py --docs-check-config phases/harness-v2-modernization/docs-checks.json --docs-check` — passed
- `git diff --check` — passed
- 결과 artifact 민감정보/thread/user-path scan — passed

## 알려진 제한 및 blocker
- 현재 환경 PATH에 `python` 명령이 없어 검증은 `uv run --isolated --no-project` fallback으로 수행했습니다.
- `checks.py --stage manual/final`은 템플릿에 `test`, `build` 명령이 아직 설정되지 않아 기존 메시지 `Missing required check commands: test, build`로 실패합니다. SDK spike 회귀와는 무관합니다.
- 외부 Codex read-only review는 비공개 저장소 egress 승인 정책으로 최초 요청과 변경 파일 allowlist로 축소한 재시도 1회가 모두 차단되었습니다. 코드 finding은 생성되지 않았지만 review gate 미완료이므로 Step 5 상태를 `blocked`로 기록했습니다.

이 PR은 review gate가 해소될 때까지 Draft로 유지합니다. Ready 전환과 병합은 이 작업 범위에 포함하지 않습니다.