### PR TITLE
fix: SDK spike 검증 오류와 리뷰 차단 해소

### DIFF
--- a/issues/harness-v2-modernization/issue-1.md
+++ b/issues/harness-v2-modernization/issue-1.md
@@ -6,14 +6,15 @@
 - Step: `5 sdk-spike`
 - GitHub Issue: `#18`
 - 분류: 외부 review gate 실행 정책 차단
+- 현재 상태: 해결 — 후속 수정의 외부 재리뷰 CLEAR (2026-09-07)
 
-## 현상
+## 최초 현상 (PR #30 작성 당시)
 
 외부 Codex read-only review를 실행하려 했으나 비공개 저장소 내용의 외부 전송에는 별도의 명시적 승인이 필요하다는 정책으로 차단되었다. 최초 요청 뒤 계약 파일과 변경 파일만 명시한 축소 재시도 1회도 같은 이유로 차단되었다.
 
 코드 또는 문서에 대한 review finding은 생성되지 않았다.
 
-## 영향
+## 최초 영향
 
 - 구현과 로컬 자동 검증은 통과했다.
 - 외부 review gate가 완료되지 않아 Step 5는 `blocked`로 유지한다.
@@ -32,3 +33,33 @@
 - phase docs-check: 통과
 - `git diff --check`: 통과
 - manual/final stage: 템플릿의 미설정 `test`, `build` 명령 때문에 실패하며 SDK spike 회귀와 무관
+
+## 후속 복구 실행 (2026-09-07)
+
+- PR #30은 `03347e086942e33611461daa635c64318fb72f45`로 develop에 병합됐다.
+  위 Draft/미병합 기록은 최초 작성 당시 상태이며 현재 PR 상태가 아니다.
+- 고정 리뷰 범위는 `git diff 75a5b3e7c51c9c464da3b4e26a238b309fac003b 03347e086942e33611461daa635c64318fb72f45`다.
+- 이번 복구의 승인 전 실행 요청 2회는 정책상 거절됐다. 명시적 승인 후 실행 1회는
+  허용 목록 밖 전역 메모리 읽기가 관찰되어 중단했고 그 결과를 채택하지 않았다.
+- 이후 허용 파일과 고정 diff만 stdin으로 전달했다. `codex exec --ignore-user-config
+  --ephemeral --skip-git-repo-check -s read-only`에 shell_tool, unified_exec, plugins,
+  apps, memories, multi_agent, hooks, skill_search 비활성화와
+  `memories.use_memories=false`, `project_doc_max_bytes=0`, `web_search="disabled"`를
+  적용하고 빈 임시 cwd에서 실행했다. 원문과 실행 식별자는 이 기록에 저장하지 않는다.
+- 완료된 최초 리뷰는 runtime pin 검증 누락, lifecycle false-positive,
+  timeout 오류 시 무기한 executor 대기 3건을 지적했다. 같은 후속 branch에서 수정했다.
+- 수정 후 전체 pytest는 245 passed다. doctor, docs-check, compileall, diff 검사와
+  artifact secret/thread/user-path 검사가 통과했다. manual/final은 기존 템플릿
+  `Missing required check commands: test, build` 제한으로 실패했다.
+- Python은 PATH에 없어 PR #30과 같은 `uv run --isolated --no-project`를 사용했고,
+  테스트는 `--with pytest python -X utf8 -m pytest scripts`로 실행했다.
+- JSON live artifact는 기존 관찰값을 보존했다. 수정 후 live SDK 재측정은 하지 않았고
+  실패 경로는 fake SDK로 검증했다. 조건부 GO, SDK opt-in, exec 기본값과 fallback은 유지한다.
+- 수정 후 외부 재리뷰 1회가 exit 0 및 `CLEAR`로 끝났다. 완료된 리뷰는 최초 1회와
+  재리뷰 1회이며, 위 정책 거절·중단 실행은 성공 리뷰 횟수에 포함하지 않는다.
+  CLI 0.146.0, 최초 기본 effort와 재리뷰 high, read-only로 실행했다.
+- Step 5를 `completed`와 한 줄 summary로 변경하고 blocked 필드를 제거했다.
+  Step 6은 `pending`이며 이번 후속 PR의 병합은 수행하지 않는다.
+- 후속 diff 자체 리뷰: 아키텍처·기술 결정·테스트·CRITICAL·task schema·후속 범위
+  격리·worktree 안전성은 통과했다. 빌드 항목은 compileall 통과와 템플릿 build
+  미설정을 구분했다. production runner와 worktree lifecycle 변경은 없다.

--- a/phases/harness-v2-modernization/SDK_SPIKE.md
+++ b/phases/harness-v2-modernization/SDK_SPIKE.md
@@ -72,6 +72,17 @@ codex exec --json --skip-git-repo-check -s read-only -C <empty-temp-dir> `
 
 ## capability 결과
 
+### 후속 review 보강 (2026-09-07)
+
+SDK와 runtime 버전을 모두 고정 검증하며 lifecycle의 인증·model·start·continue·
+resume 검사가 모두 참일 때만 `passed`를 기록한다. timeout probe는 interrupt와
+client close를 각각 최대 5초, terminal wait를 최대 30초 기다린다. 오류 경로에서도
+client close를 시도하며 daemon worker로 무기한 executor 종료 대기를 피한다.
+SDK close 자체가 멈추면 실패로 보고하고 반환하지만 남은 SDK 자식 프로세스의 정리까지
+보장하지 않는다. 이는 spike의 실패 진단 보강이며 production timeout 보장이 아니다.
+기존 JSON은 2026-09-06 live 관찰값이며, 이 수정 이후 live 재측정 결과로 바꾸지 않았다.
+수정은 fake SDK 회귀 테스트로 검증하며 조건부 GO와 opt-in/exec fallback 전제는 유지한다.
+
 | capability | 기대 결과 | 실제 결과 | 판정 |
 | --- | --- | --- | --- |
 | stable package / runtime pin | 같은 버전의 SDK와 runtime 설치 | 둘 다 `0.147.0` | 가능 |

--- a/phases/harness-v2-modernization/index.json
+++ b/phases/harness-v2-modernization/index.json
@@ -40,9 +40,8 @@
     {
       "step": 5,
       "name": "sdk-spike",
-      "status": "blocked",
-      "blocked_at": "2026-09-06T19:20:37+0900",
-      "blocked_reason": "외부 Codex read-only review가 비공개 저장소 egress 승인 정책으로 최초 1회와 축소 재시도 1회 모두 차단되어 review gate를 완료하지 못했다. 구현 및 로컬 검증은 통과했다."
+      "status": "completed",
+      "summary": "SDK spike의 조건부 GO와 exec fallback을 유지하고 외부 리뷰 3건을 수정했으며 재리뷰 CLEAR와 245개 테스트로 Step 5 gate를 해소했다."
     },
     { "step": 6, "name": "runner-adapter", "status": "pending" },
     { "step": 7, "name": "resumable-telemetry", "status": "pending" },

--- a/scripts/sdk_spike.py
+++ b/scripts/sdk_spike.py
@@ -12,6 +12,7 @@ import platform
 import re
 import sys
 import tempfile
+import threading
 import time
 from pathlib import Path
 from types import ModuleType
@@ -22,6 +23,8 @@ SDK_DISTRIBUTION = "openai-codex"
 RUNTIME_DISTRIBUTION = "openai-codex-cli-bin"
 PINNED_SDK_VERSION = "0.147.0"
 DEFAULT_MODEL = "gpt-5.6-terra"
+TERMINAL_WAIT_SECONDS = 30.0
+CLEANUP_WAIT_SECONDS = 5.0
 
 _SENSITIVE_KEY_RE = re.compile(
     r"(?:credential|token|password|api[_-]?key|thread[_-]?id|response[_-]?(?:text|body)|prompt)",
@@ -43,10 +46,10 @@ def _version(distribution: str) -> str:
     return importlib.metadata.version(distribution)
 
 
-def require_pinned_version(actual: str) -> None:
+def require_pinned_version(actual: str, distribution: str = SDK_DISTRIBUTION) -> None:
     if actual != PINNED_SDK_VERSION:
         raise SpikeError(
-            f"expected {SDK_DISTRIBUTION}=={PINNED_SDK_VERSION}, got {actual}"
+            f"expected {distribution}=={PINNED_SDK_VERSION}, got {actual}"
         )
 
 
@@ -99,6 +102,7 @@ def build_static_report() -> tuple[dict[str, Any], ModuleType]:
     sdk_version = _version(SDK_DISTRIBUTION)
     require_pinned_version(sdk_version)
     runtime_version = _version(RUNTIME_DISTRIBUTION)
+    require_pinned_version(runtime_version, RUNTIME_DISTRIBUTION)
     import openai_codex as sdk
 
     report = {
@@ -168,8 +172,10 @@ def _probe_thread_lifecycle(sdk: ModuleType, cwd: str, model: str) -> dict[str, 
             same_identifier = resumed.id == thread_identifier
             resumed_codex.thread_archive(thread_identifier)
 
+        passed = all((getattr(account, "account", None) is not None,
+                      model in model_ids, started, continued, resumed_ok, same_identifier))
         return {
-            "status": "passed",
+            "status": "passed" if passed else "failed",
             "authenticated": getattr(account, "account", None) is not None,
             "model": model,
             "modelAdvertised": model in model_ids,
@@ -246,6 +252,20 @@ def _probe_error_recovery(sdk: ModuleType, cwd: str, model: str) -> dict[str, An
         return classify_exception(exc)
 
 
+def _daemon_call(action: Callable[[], Any]) -> concurrent.futures.Future:
+    """A stuck SDK call must not register an unbounded interpreter-exit join."""
+    future = concurrent.futures.Future()
+
+    def run() -> None:
+        try:
+            future.set_result(action())
+        except BaseException as exc:
+            future.set_exception(exc)
+
+    threading.Thread(target=run, daemon=True).start()
+    return future
+
+
 def _probe_timeout_and_interrupt(
     sdk: ModuleType,
     cwd: str,
@@ -253,7 +273,6 @@ def _probe_timeout_and_interrupt(
     timeout_seconds: float,
 ) -> dict[str, Any]:
     command = "Start-Sleep -Seconds 30" if sys.platform == "win32" else "sleep 30"
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
     codex = None
     timed_out = False
     interrupted = False
@@ -270,17 +289,17 @@ def _probe_timeout_and_interrupt(
         handle = thread.turn(
             f"Run this exact shell command before replying: {command}. Then reply DONE."
         )
-        future = executor.submit(handle.run)
+        future = _daemon_call(handle.run)
         try:
             future.result(timeout=timeout_seconds)
         except concurrent.futures.TimeoutError:
             timed_out = True
-            handle.interrupt()
+            _daemon_call(handle.interrupt).result(timeout=CLEANUP_WAIT_SECONDS)
             interrupted = True
-        result = future.result(timeout=30)
+        result = future.result(timeout=TERMINAL_WAIT_SECONDS)
         terminal = str(getattr(result, "status", "unknown"))
         passed = timed_out and interrupted and terminal.lower().endswith("interrupted")
-        return {
+        report = {
             "status": "passed" if passed else "failed",
             "sdkNativeTimeoutParameter": False,
             "callerTimeoutTriggered": timed_out,
@@ -288,11 +307,14 @@ def _probe_timeout_and_interrupt(
             "terminalStatus": terminal.split(".")[-1].lower(),
         }
     except Exception as exc:
-        return classify_exception(exc)
+        report = classify_exception(exc)
     finally:
-        executor.shutdown(wait=True)
         if codex is not None:
-            codex.close()
+            try:
+                _daemon_call(codex.close).result(timeout=CLEANUP_WAIT_SECONDS)
+            except Exception as exc:
+                report = classify_exception(exc)
+    return report
 
 
 def run_live_probes(

--- a/scripts/tests/test_sdk_spike.py
+++ b/scripts/tests/test_sdk_spike.py
@@ -1,4 +1,6 @@
 import json
+import threading
+import time
 from enum import Enum
 from pathlib import Path
 from types import SimpleNamespace
@@ -6,6 +8,87 @@ from types import SimpleNamespace
 import pytest
 
 import sdk_spike
+
+
+def test_runtime_version_mismatch_fails_before_sdk_import(monkeypatch):
+    monkeypatch.setattr(sdk_spike, "_version", lambda name:
+                        "0.148.0" if name == sdk_spike.RUNTIME_DISTRIBUTION else "0.147.0")
+    with pytest.raises(sdk_spike.SpikeError, match="openai-codex-cli-bin"):
+        sdk_spike.build_static_report()
+
+
+@pytest.mark.parametrize("failed", [None, "auth", "model", "start", "continue", "resume", "identity"])
+def test_lifecycle_requires_every_check(monkeypatch, failed):
+    class Client:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def account(self):
+            return SimpleNamespace(account=None if failed == "auth" else object())
+
+        def models(self):
+            return SimpleNamespace(data=[] if failed == "model" else [SimpleNamespace(model="test")])
+
+        def thread_start(self, **kwargs):
+            return SimpleNamespace(id="fixture")
+
+        def thread_resume(self, *args, **kwargs):
+            return SimpleNamespace(id="different" if failed == "identity" else "fixture")
+
+        def thread_archive(self, *args):
+            pass
+
+    outcomes = iter([(failed != key, 0.0) for key in ("start", "continue", "resume")])
+    monkeypatch.setattr(sdk_spike, "_run_text_turn", lambda *args: next(outcomes))
+    sdk = SimpleNamespace(Codex=Client, Sandbox=SimpleNamespace(read_only="read-only"),
+                          ApprovalMode=SimpleNamespace(deny_all="deny_all"))
+    result = sdk_spike._probe_thread_lifecycle(sdk, ".", "test")
+    assert result["status"] == ("passed" if failed is None else "failed")
+
+
+@pytest.mark.parametrize("failure", ["interrupt", "terminal", "close", None])
+def test_timeout_cleanup_is_bounded_and_fail_closed(monkeypatch, failure):
+    released = threading.Event()
+    closed = threading.Event()
+    monkeypatch.setattr(sdk_spike, "TERMINAL_WAIT_SECONDS", 0.03)
+    monkeypatch.setattr(sdk_spike, "CLEANUP_WAIT_SECONDS", 0.03)
+
+    class Handle:
+        def run(self):
+            released.wait(2)
+            return SimpleNamespace(status="interrupted")
+
+        def interrupt(self):
+            if failure == "interrupt":
+                raise RuntimeError("private message")
+            if failure not in ("terminal", "close"):
+                released.set()
+
+    class Client:
+        def thread_start(self, **kwargs):
+            return SimpleNamespace(turn=lambda *args: Handle())
+
+        def close(self):
+            closed.set()
+            if failure == "close":
+                released.wait(2)
+            else:
+                released.set()
+
+    sdk = SimpleNamespace(Codex=Client, Sandbox=SimpleNamespace(read_only="read-only"),
+                          ApprovalMode=SimpleNamespace(auto_review="auto_review"))
+    started = time.monotonic()
+    try:
+        result = sdk_spike._probe_timeout_and_interrupt(sdk, ".", "test", 0.01)
+        assert time.monotonic() - started < 1
+        assert closed.is_set()
+        assert result["status"] == ("passed" if failure is None else "failed")
+        sdk_spike.assert_safe_report(result)
+    finally:
+        released.set()
 
 
 def test_require_pinned_version_rejects_drift():


### PR DESCRIPTION
Closes #18

PR #30의 외부 리뷰 gate를 재수행해 발견한 세 문제를 수정했습니다. SDK와 runtime 버전을 모두 검증하고, lifecycle 검사 전체가 참일 때만 성공으로 기록하며, timeout 오류 경로의 무기한 executor 대기를 제한했습니다. 회귀 테스트 12개를 추가했습니다.

고정 최초 리뷰 범위: `75a5b3e7c51c9c464da3b4e26a238b309fac003b..03347e086942e33611461daa635c64318fb72f45` (PR #30).

- 완료된 외부 리뷰: 최초 1회 findings 3건, 수정 후 재리뷰 1회 CLEAR (exit 0).
- 이번 복구에서 승인 전 정책 거절 2회, 승인 후 허용 목록 밖 메모리 읽기로 중단 1회는 성공 리뷰로 계산하지 않았습니다. 이후 허용 소스와 diff만 stdin으로 전달하고 shell/메모리/플러그인 등을 끈 read-only CLI로 검토했습니다.
- Step 5를 completed로 갱신하고 blocked 필드를 제거했습니다. 실패 이력과 해결 근거는 issue-1.md에 보존했습니다. Step 6은 pending입니다.

검증: `uv run --isolated --no-project --with pytest python -X utf8 -m pytest scripts` 245 passed; 같은 uv 환경의 doctor --template, phase docs-check, compileall, git diff --check 및 artifact secret/thread/user-path scan 통과. Python이 PATH에 없고 sandbox에서 uv 실행이 거부되어 승인된 외부 실행을 사용했습니다. manual/final은 기존 템플릿의 `Missing required check commands: test, build`로 실패합니다.

조건부 GO, production codex exec 기본값, SDK opt-in과 명시적 exec fallback을 유지합니다. native high-level timeout/review API 부재는 그대로입니다. 기존 live JSON은 보존했고 수정 후 live 재측정은 하지 않았습니다. 종료가 멈춘 SDK 자식 프로세스의 정리까지 보장하지 않는 한계는 SDK_SPIKE.md에 명시했습니다. 후속 diff 자체 리뷰 통과. 이 작업은 PR 생성까지만 수행합니다.
