### PR TITLE
refactor: Codex runner adapter와 exec fallback 도입

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,6 +11,7 @@
 
 ```text
 scripts/
+  codex_runner.py  # exec 기본/SDK opt-in, 정규화 결과와 bounded fallback 경계
   execute.py       # 한 task의 구현과 acceptance 재검증
   autopilot.py     # task별 PR, review, merge 직렬 루프
   worktree.py      # task worktree와 administrative marker lifecycle
@@ -33,6 +34,10 @@ phases/{phase}/
   phase 상태 기록을 수행한다.
 - `autopilot.py`: primary의 repository lock 안에서 base fetch, worktree 준비,
   execute subprocess, PR/review/merge, 성공 정리를 한 번에 하나씩 조정한다.
+- `codex_runner.py`: `start`, `run`, `resume`, `review`, `interrupt` 공통 contract와
+  비민감 정규화 결과를 제공한다. production 기본은 `codex exec`이며 Python SDK는
+  명시 opt-in이다. SDK pin/capability/실행 오류는 기존 sandbox·approval·환경 정책을
+  가진 exec 경로로만 recoverable fallback한다.
 
 ## 데이터 흐름
 

--- a/issues/harness-v2-modernization/issue-2.md
+++ b/issues/harness-v2-modernization/issue-2.md
@@ -1,0 +1,42 @@
+# Issue 2: Step 6 SDK caller-deadline 외부 리뷰 차단
+
+## 상태
+
+- Phase: `harness-v2-modernization`
+- Step: `6 runner-adapter`
+- GitHub Issue: `#19`
+- PR: `#32`
+- 분류: 외부 read-only review P1 및 재리뷰 횟수 소진
+- 현재 상태: 차단 — 수정은 반영됐으나 외부 CLEAR 재검증 대기
+
+## 현상과 수정
+
+최종 허용 재리뷰는 SDK turn을 daemon thread에서 실행한 뒤 timeout에 interrupt와
+close를 시도해도, 종료되지 않은 turn이 worktree를 계속 변경할 수 있다고 지적했다.
+
+이를 해소하기 위해 caller deadline이 있는 SDK 실행은 시작 전에 recoverable capability
+오류로 거부하고, `FallbackRunner`가 timeout을 강제할 수 있는 exec adapter로 넘기도록
+변경했다. SDK의 명시적 interrupt와 close는 계속 bounded, fail-closed 처리한다.
+
+## 리뷰 이력
+
+- 최초 외부 review: process timeout 정규화, read-only worktree 검사, review/fix session
+  분리 P1 3건을 수정했다.
+- 재리뷰 1회: explicit SDK interrupt가 무기한 대기할 수 있는 P1 1건을 수정했다.
+- 재리뷰 2회: SDK caller-deadline turn의 잔류 실행 P1 1건을 확인했고, 위 fallback
+  경계로 로컬 수정했다.
+
+계약상 재리뷰은 최대 2회이므로 추가 외부 재리뷰 없이 PR을 Draft로 유지한다.
+
+## 복구 조건
+
+사용자가 추가 외부 재리뷰 또는 동등한 독립 검증을 승인한 뒤, 고정 head에서 CLEAR를
+확인한다. 그 전에는 Step 6을 완료로 표시하거나 PR을 Ready로 전환하지 않는다.
+
+## 로컬 검증
+
+- runner adapter targeted pytest
+- 전체 `scripts` pytest
+- compileall, template doctor, phase docs-check, `git diff --check`
+
+Python PATH가 없는 환경에서는 `uv run --isolated --no-project`로 pytest를 실행한다.

--- a/phases/harness-v2-modernization/index.json
+++ b/phases/harness-v2-modernization/index.json
@@ -46,8 +46,8 @@
     {
       "step": 6,
       "name": "runner-adapter",
-      "status": "completed",
-      "summary": "공통 runner adapter에 exec 기본·SDK opt-in·정규화 결과와 recoverable fallback을 도입하고 executor/autopilot의 Codex 호출 세부사항을 분리했다."
+      "status": "blocked",
+      "blocked_reason": "외부 read-only review의 SDK caller-deadline 안전성 P1은 수정했지만, 허용된 재리뷰 2회를 모두 사용하여 CLEAR 재검증이 필요하다."
     },
     { "step": 7, "name": "resumable-telemetry", "status": "pending" },
     { "step": 8, "name": "risk-based-review", "status": "pending" },

--- a/phases/harness-v2-modernization/index.json
+++ b/phases/harness-v2-modernization/index.json
@@ -43,7 +43,12 @@
       "status": "completed",
       "summary": "SDK spike의 조건부 GO와 exec fallback을 유지하고 외부 리뷰 3건을 수정했으며 재리뷰 CLEAR와 245개 테스트로 Step 5 gate를 해소했다."
     },
-    { "step": 6, "name": "runner-adapter", "status": "pending" },
+    {
+      "step": 6,
+      "name": "runner-adapter",
+      "status": "completed",
+      "summary": "공통 runner adapter에 exec 기본·SDK opt-in·정규화 결과와 recoverable fallback을 도입하고 executor/autopilot의 Codex 호출 세부사항을 분리했다."
+    },
     { "step": 7, "name": "resumable-telemetry", "status": "pending" },
     { "step": 8, "name": "risk-based-review", "status": "pending" },
     { "step": 9, "name": "bounded-dag", "status": "pending" },

--- a/scripts/autopilot.py
+++ b/scripts/autopilot.py
@@ -212,6 +212,7 @@ class AutopilotRunner:
         self._scope_rules_cache: dict | None = None
         self._global_scope_rules_cache: dict | None = None
         self._runner_sessions: dict[int, RunnerSession] = {}
+        self._fix_sessions: dict[int, RunnerSession] = {}
 
     # --- command helpers ---
 
@@ -1164,15 +1165,23 @@ class AutopilotRunner:
 
     def _runner_process(self, cmd, *, input, capture_output, text, timeout):
         """Adapt the runner's subprocess boundary to the active task worktree."""
-        if self._active_worktree is None:
-            return self._run(cmd, check=False, timeout=timeout, input_text=input)
-        return self._run(cmd, check=False, timeout=timeout, input_text=input, cwd=self._active_worktree)
+        # _run is retained for the active-worktree boundary and test seam, but
+        # its timeout error is translated back so the adapter owns normalization.
+        try:
+            if self._active_worktree is None:
+                return self._run(cmd, check=False, timeout=timeout, input_text=input)
+            return self._run(cmd, check=False, timeout=timeout, input_text=input, cwd=self._active_worktree)
+        except AutopilotError as exc:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout) from exc
 
     def _run_codex_review(self, step: dict) -> ReviewResult:
         prompt = self._codex_review_prompt(step)
         before_status = self._worktree_status()
         schema_path = self._write_review_output_schema()
         last_message_path = self._temporary_path(".txt")
+        runner_error: RunnerError | None = None
+        result = None
+        last_message = ""
         try:
             runner = build_runner(process_runner=self._runner_process)
             result = runner.review(
@@ -1191,7 +1200,7 @@ class AutopilotRunner:
                 self._runner_sessions[step["step"]] = RunnerSession(result.adapter, result.thread_id)
             last_message = result.final_message
         except RunnerError as exc:
-            return ReviewResult(False, ["자체 리뷰 실행 실패: runner error"], str(exc), codex_passed=False)
+            runner_error = exc
         finally:
             schema_path.unlink(missing_ok=True)
             last_message_path.unlink(missing_ok=True)
@@ -1206,6 +1215,10 @@ class AutopilotRunner:
                 "자체 리뷰가 worktree를 변경했습니다.",
                 codex_passed=False,
             )
+        if runner_error is not None:
+            return ReviewResult(False, ["자체 리뷰 실행 실패: runner error"], str(runner_error), codex_passed=False)
+        if result is None:
+            return ReviewResult(False, ["자체 리뷰 실행 실패: runner result 없음"], "자체 리뷰 실행 실패", codex_passed=False)
         if not result.ok:
             return ReviewResult(
                 False,
@@ -1462,10 +1475,13 @@ class AutopilotRunner:
         )
         runner = build_runner(process_runner=self._runner_process)
         request = RunnerRequest(prompt=prompt, effort=self.fix_effort, timeout=CODEX_EXEC_TIMEOUT)
-        session = self._runner_sessions.get(step["step"])
+        # A review session begins read-only. Fix work must use its own write-capable session.
+        session = self._fix_sessions.get(step["step"])
         result = runner.resume(session, request) if session is not None else runner.start(request)
         if not result.ok:
             raise AutopilotError(f"Codex review-fix runner 실패: {result.error_kind or result.exit_code}")
+        if result.thread_id:
+            self._fix_sessions[step["step"]] = RunnerSession(result.adapter, result.thread_id)
 
     def _commit_dirty_fix(self, step: dict):
         git_root = self._active_worktree or self.root

--- a/scripts/autopilot.py
+++ b/scripts/autopilot.py
@@ -23,15 +23,13 @@ from codex_common import (
     CODEX_ENV_CONFIG,
     CODEX_ENV_SECRET_FILTER_CONFIG,
     CODEX_EXEC_TIMEOUT,
-    codex_base_cmd,
     configure_utf8_stdio,
     read_acceptance_commands,
-    resolve_codex_bin,
     validate_codex_effort,
 )
+from codex_runner import RunnerError, RunnerRequest, RunnerSession, build_runner
 
 ROOT = Path(__file__).resolve().parent.parent
-CODEX_BIN = resolve_codex_bin()
 DEFAULT_STEP_EFFORT = "medium"
 DEFAULT_REVIEW_EFFORT = "high"
 DEFAULT_FIX_EFFORT = "medium"
@@ -213,6 +211,7 @@ class AutopilotRunner:
         self._active_worktree: Path | None = None
         self._scope_rules_cache: dict | None = None
         self._global_scope_rules_cache: dict | None = None
+        self._runner_sessions: dict[int, RunnerSession] = {}
 
     # --- command helpers ---
 
@@ -1163,40 +1162,36 @@ class AutopilotRunner:
 
     # --- Codex read-only review ---
 
+    def _runner_process(self, cmd, *, input, capture_output, text, timeout):
+        """Adapt the runner's subprocess boundary to the active task worktree."""
+        if self._active_worktree is None:
+            return self._run(cmd, check=False, timeout=timeout, input_text=input)
+        return self._run(cmd, check=False, timeout=timeout, input_text=input, cwd=self._active_worktree)
+
     def _run_codex_review(self, step: dict) -> ReviewResult:
         prompt = self._codex_review_prompt(step)
         before_status = self._worktree_status()
         schema_path = self._write_review_output_schema()
         last_message_path = self._temporary_path(".txt")
         try:
-            cmd = [
-                *codex_base_cmd(self.review_effort),
-                "--output-schema",
-                str(schema_path),
-                "--output-last-message",
-                str(last_message_path),
-                "-",
-            ]
-            if self._active_worktree is None:
-                result = self._run(
-                    cmd,
-                    check=False,
+            runner = build_runner(process_runner=self._runner_process)
+            result = runner.review(
+                None,
+                RunnerRequest(
+                    prompt=prompt,
+                    mode="review",
+                    effort=self.review_effort,
+                    sandbox="read-only",
                     timeout=CODEX_EXEC_TIMEOUT,
-                    input_text=prompt,
-                )
-            else:
-                result = self._run(
-                    cmd,
-                    check=False,
-                    timeout=CODEX_EXEC_TIMEOUT,
-                    input_text=prompt,
-                    cwd=self._active_worktree,
-                )
-            last_message = (
-                last_message_path.read_text(encoding="utf-8")
-                if last_message_path.exists()
-                else ""
+                    output_schema=str(schema_path),
+                    output_last_message=str(last_message_path),
+                ),
             )
+            if result.thread_id:
+                self._runner_sessions[step["step"]] = RunnerSession(result.adapter, result.thread_id)
+            last_message = result.final_message
+        except RunnerError as exc:
+            return ReviewResult(False, ["자체 리뷰 실행 실패: runner error"], str(exc), codex_passed=False)
         finally:
             schema_path.unlink(missing_ok=True)
             last_message_path.unlink(missing_ok=True)
@@ -1211,22 +1206,14 @@ class AutopilotRunner:
                 "자체 리뷰가 worktree를 변경했습니다.",
                 codex_passed=False,
             )
-        if result.returncode != 0:
+        if not result.ok:
             return ReviewResult(
                 False,
-                [
-                    self._command_failure(
-                        [
-                            *codex_base_cmd(self.review_effort),
-                            "<review-prompt>",
-                        ],
-                        result,
-                    )
-                ],
+                [f"자체 리뷰 실행 실패: {result.error_kind or 'runner failure'}"],
                 "자체 리뷰 실행 실패",
                 codex_passed=False,
             )
-        parsed = self._review_from_text(last_message) or self._parse_review_result(result.stdout)
+        parsed = self._review_from_text(last_message)
         if parsed is None:
             parsed = self._parse_native_review_text(last_message)
         if parsed is None:
@@ -1473,18 +1460,12 @@ class AutopilotRunner:
             f"{review.to_markdown()}\n\n"
             "수정 후 가능한 검증을 실행하고, 수정한 파일은 working tree에 남겨두세요."
         )
-        cmd = codex_base_cmd(self.fix_effort)
-        # 프롬프트는 argv 대신 stdin으로 전달해서 ARG_MAX 한계를 피한다.
-        cmd.append("-")
-        if self._active_worktree is None:
-            self._run(cmd, timeout=CODEX_EXEC_TIMEOUT, input_text=prompt)
-        else:
-            self._run(
-                cmd,
-                timeout=CODEX_EXEC_TIMEOUT,
-                input_text=prompt,
-                cwd=self._active_worktree,
-            )
+        runner = build_runner(process_runner=self._runner_process)
+        request = RunnerRequest(prompt=prompt, effort=self.fix_effort, timeout=CODEX_EXEC_TIMEOUT)
+        session = self._runner_sessions.get(step["step"])
+        result = runner.resume(session, request) if session is not None else runner.start(request)
+        if not result.ok:
+            raise AutopilotError(f"Codex review-fix runner 실패: {result.error_kind or result.exit_code}")
 
     def _commit_dirty_fix(self, step: dict):
         git_root = self._active_worktree or self.root

--- a/scripts/codex_runner.py
+++ b/scripts/codex_runner.py
@@ -263,7 +263,8 @@ class SdkRunner:
             interrupt = getattr(thread, "interrupt", None)
             if not callable(interrupt):
                 return RunnerResult(False, self.name, error_kind="interrupt_unsupported")
-            interrupt()
+            if not self._bounded_call(interrupt):
+                return RunnerResult(False, self.name, error_kind="interrupt_timeout")
             return RunnerResult.success(self.name)
         except Exception:
             return RunnerResult(False, self.name, error_kind="interrupt_failed")

--- a/scripts/codex_runner.py
+++ b/scripts/codex_runner.py
@@ -1,0 +1,321 @@
+"""Stable runner boundary for Codex CLI and the optional Python SDK.
+
+This module is the only Harness layer that knows Codex argv or SDK call shapes.
+It deliberately exposes a small, sanitized result surface: callers may keep a
+thread id in memory for resume, but must not persist it in phase artifacts.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import os
+import subprocess
+import threading
+from dataclasses import dataclass
+from typing import Callable, Protocol
+
+from codex_common import CODEX_EXEC_TIMEOUT, codex_base_cmd
+
+SDK_PACKAGE = "openai-codex"
+SDK_PIN = "0.147.0"
+
+
+class RunnerError(RuntimeError):
+    recoverable = False
+
+
+class RunnerCapabilityError(RunnerError):
+    recoverable = True
+
+
+class RunnerExecutionError(RunnerError):
+    def __init__(self, message: str, *, recoverable: bool = False):
+        super().__init__(message)
+        self.recoverable = recoverable
+
+
+@dataclass(frozen=True)
+class RunnerRequest:
+    prompt: str
+    mode: str = "run"
+    effort: str = "medium"
+    sandbox: str | None = None
+    timeout: int = CODEX_EXEC_TIMEOUT
+    unsafe: bool = False
+    output_schema: str | None = None
+    output_last_message: str | None = None
+
+
+@dataclass(frozen=True)
+class RunnerSession:
+    adapter: str
+    thread_id: str | None = None
+
+
+@dataclass(frozen=True)
+class RunnerResult:
+    ok: bool
+    adapter: str
+    exit_code: int = 0
+    final_message: str = ""
+    thread_id: str | None = None
+    error_kind: str | None = None
+    fallback_reason: str | None = None
+
+    @classmethod
+    def success(cls, adapter: str, **kwargs) -> "RunnerResult":
+        return cls(True, adapter, **kwargs)
+
+    def to_record(self) -> dict:
+        """Return a commit-safe record; never include thread/prompt/raw output."""
+        return {
+            "ok": self.ok,
+            "adapter": self.adapter,
+            "exitCode": self.exit_code,
+            "errorKind": self.error_kind,
+            "fallbackReason": self.fallback_reason,
+        }
+
+
+class RunnerAdapter(Protocol):
+    name: str
+    def start(self, request: RunnerRequest) -> RunnerResult: ...
+    def run(self, session: RunnerSession, request: RunnerRequest) -> RunnerResult: ...
+    def resume(self, session: RunnerSession, request: RunnerRequest) -> RunnerResult: ...
+    def review(self, session: RunnerSession | None, request: RunnerRequest) -> RunnerResult: ...
+    def interrupt(self, session: RunnerSession) -> RunnerResult: ...
+    def close(self) -> None: ...
+
+
+def runner_preference() -> str:
+    preference = os.environ.get("HARNESS_CODEX_RUNNER", "exec").strip().lower() or "exec"
+    if preference not in {"exec", "sdk"}:
+        raise RunnerCapabilityError("HARNESS_CODEX_RUNNER must be 'exec' or explicit opt-in 'sdk'")
+    return preference
+
+
+def _thread_id(stdout: str) -> str | None:
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        for key in ("thread_id", "threadId", "session_id", "sessionId"):
+            value = event.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
+class ExecRunner:
+    name = "exec"
+
+    def __init__(self, *, run_process: Callable[..., subprocess.CompletedProcess] | None = None):
+        # Resolve at construction so unit-test monkeypatches and runtime wrappers apply.
+        self._run_process = run_process or subprocess.run
+
+    def _command(self, request: RunnerRequest, *, resume: str | None = None) -> list[str]:
+        cmd = codex_base_cmd(request.effort)
+        if resume:
+            cmd = [cmd[0], "exec", "resume", resume, *cmd[2:]]
+        if request.sandbox:
+            cmd.extend(["--sandbox", request.sandbox])
+        if request.unsafe:
+            cmd.append("--dangerously-bypass-approvals-and-sandbox")
+        if request.output_schema:
+            cmd.extend(["--output-schema", request.output_schema])
+        if request.output_last_message:
+            cmd.extend(["--output-last-message", request.output_last_message])
+        cmd.append("-")
+        return cmd
+
+    def _invoke(self, request: RunnerRequest, *, resume: str | None = None) -> RunnerResult:
+        cmd = self._command(request, resume=resume)
+        try:
+            completed = self._run_process(
+                cmd, input=request.prompt, capture_output=True, text=True, timeout=request.timeout
+            )
+        except subprocess.TimeoutExpired as exc:
+            return RunnerResult(False, self.name, 124, error_kind="timeout")
+        except OSError as exc:
+            raise RunnerExecutionError("codex exec could not start", recoverable=True) from exc
+        message = ""
+        if request.output_last_message:
+            try:
+                with open(request.output_last_message, encoding="utf-8") as file:
+                    message = file.read()
+            except OSError:
+                pass
+        if not message:
+            message = completed.stdout or ""
+        if completed.returncode:
+            return RunnerResult(False, self.name, completed.returncode, error_kind="exec_failed")
+        return RunnerResult.success(self.name, final_message=message, thread_id=_thread_id(completed.stdout or ""))
+
+    def start(self, request: RunnerRequest) -> RunnerResult:
+        return self._invoke(request)
+
+    def run(self, session: RunnerSession, request: RunnerRequest) -> RunnerResult:
+        return self.resume(session, request) if session.thread_id else self.start(request)
+
+    def resume(self, session: RunnerSession, request: RunnerRequest) -> RunnerResult:
+        if not session.thread_id:
+            raise RunnerCapabilityError("resume requires an in-memory runner session")
+        return self._invoke(request, resume=session.thread_id)
+
+    def review(self, session: RunnerSession | None, request: RunnerRequest) -> RunnerResult:
+        return self.run(session, request) if session else self.start(request)
+
+    def interrupt(self, session: RunnerSession) -> RunnerResult:
+        return RunnerResult(False, self.name, error_kind="interrupt_unsupported")
+
+    def close(self) -> None:
+        return None
+
+
+class SdkRunner:
+    """Best-effort SDK adapter, selected only by explicit feature flag."""
+    name = "sdk"
+
+    def __init__(self):
+        try:
+            installed = importlib.metadata.version(SDK_PACKAGE)
+        except importlib.metadata.PackageNotFoundError as exc:
+            raise RunnerCapabilityError("Python Codex SDK is not installed") from exc
+        if installed != SDK_PIN:
+            raise RunnerCapabilityError("Python Codex SDK/runtime pin does not match ADR-0005")
+        try:
+            from openai_codex import Codex, Sandbox  # type: ignore
+        except ImportError as exc:
+            raise RunnerCapabilityError("Python Codex SDK import failed") from exc
+        self._codex = Codex()
+        self._sandbox = Sandbox
+        self._threads: dict[str, object] = {}
+
+    def _run_thread(self, thread: object, request: RunnerRequest) -> RunnerResult:
+        outcome: dict[str, object] = {}
+        failure: list[BaseException] = []
+
+        def invoke() -> None:
+            try:
+                outcome["result"] = thread.run(request.prompt)
+            except BaseException as exc:  # SDK typed errors vary across pinned runtime surfaces.
+                failure.append(exc)
+
+        worker = threading.Thread(target=invoke, daemon=True)
+        worker.start()
+        worker.join(request.timeout)
+        if worker.is_alive():
+            # ADR-0005 requires bounded, fail-closed cleanup; never report a timed-out turn as success.
+            self._bounded_call(getattr(thread, "interrupt", None))
+            self._bounded_call(getattr(self._codex, "close", None))
+            return RunnerResult(False, self.name, 124, error_kind="timeout")
+        if failure:
+            raise RunnerExecutionError("SDK run failed", recoverable=True) from failure[0]
+        result = outcome.get("result")
+        thread_id = getattr(thread, "id", None) or getattr(thread, "thread_id", None)
+        return RunnerResult.success(self.name, final_message=str(getattr(result, "final_response", "")), thread_id=thread_id)
+
+    @staticmethod
+    def _bounded_call(callback: object, timeout: float = 5.0) -> bool:
+        if not callable(callback):
+            return False
+        worker = threading.Thread(target=callback, daemon=True)
+        worker.start()
+        worker.join(timeout)
+        return not worker.is_alive()
+
+    def start(self, request: RunnerRequest) -> RunnerResult:
+        sandbox = getattr(self._sandbox, "workspace_write") if request.sandbox != "read-only" else getattr(self._sandbox, "read_only")
+        try:
+            thread = self._codex.thread_start(sandbox=sandbox)
+        except Exception as exc:
+            raise RunnerExecutionError("SDK thread start failed", recoverable=True) from exc
+        result = self._run_thread(thread, request)
+        if result.thread_id:
+            self._threads[result.thread_id] = thread
+        return result
+
+    def run(self, session: RunnerSession, request: RunnerRequest) -> RunnerResult:
+        return self.resume(session, request) if session.thread_id else self.start(request)
+
+    def resume(self, session: RunnerSession, request: RunnerRequest) -> RunnerResult:
+        if not session.thread_id:
+            raise RunnerCapabilityError("resume requires an in-memory runner session")
+        thread = self._threads.get(session.thread_id)
+        if thread is None:
+            try:
+                thread = self._codex.thread_resume(session.thread_id)
+            except Exception as exc:
+                raise RunnerExecutionError("SDK resume failed", recoverable=True) from exc
+        return self._run_thread(thread, request)
+
+    def review(self, session: RunnerSession | None, request: RunnerRequest) -> RunnerResult:
+        # ADR-0005: native review remains out of scope; run the read-only turn.
+        return self.run(session, request) if session else self.start(request)
+
+    def interrupt(self, session: RunnerSession) -> RunnerResult:
+        thread = self._threads.get(session.thread_id or "")
+        try:
+            interrupt = getattr(thread, "interrupt", None)
+            if not callable(interrupt):
+                return RunnerResult(False, self.name, error_kind="interrupt_unsupported")
+            interrupt()
+            return RunnerResult.success(self.name)
+        except Exception:
+            return RunnerResult(False, self.name, error_kind="interrupt_failed")
+
+    def close(self) -> None:
+        self._bounded_call(getattr(self._codex, "close", None))
+
+
+class FallbackRunner:
+    """Fallback only for recoverable SDK capability/execution failures."""
+    def __init__(self, primary: RunnerAdapter, fallback: RunnerAdapter):
+        self.primary, self.fallback, self.name = primary, fallback, primary.name
+
+    def _call(self, method: str, *args) -> RunnerResult:
+        try:
+            return getattr(self.primary, method)(*args)
+        except RunnerError as exc:
+            if not exc.recoverable:
+                raise
+            result = getattr(self.fallback, method)(*args)
+            return RunnerResult(
+                result.ok, result.adapter, result.exit_code, result.final_message, result.thread_id,
+                result.error_kind, fallback_reason=str(exc),
+            )
+
+    def start(self, request: RunnerRequest) -> RunnerResult: return self._call("start", request)
+    def run(self, session: RunnerSession, request: RunnerRequest) -> RunnerResult: return self._call("run", session, request)
+    def resume(self, session: RunnerSession, request: RunnerRequest) -> RunnerResult: return self._call("resume", session, request)
+    def review(self, session: RunnerSession | None, request: RunnerRequest) -> RunnerResult: return self._call("review", session, request)
+    def interrupt(self, session: RunnerSession) -> RunnerResult: return self._call("interrupt", session)
+    def close(self) -> None:
+        self.primary.close()
+        self.fallback.close()
+
+
+def build_runner(*, process_runner: Callable[..., subprocess.CompletedProcess] | None = None) -> RunnerAdapter:
+    exec_runner = ExecRunner(run_process=process_runner)
+    if runner_preference() == "exec":
+        return exec_runner
+    try:
+        return FallbackRunner(SdkRunner(), exec_runner)
+    except RunnerCapabilityError as exc:
+        # Selecting SDK remains explicit, but a missing/incompatible optional SDK is safe to fall back.
+        return FallbackRunner(_UnavailableSdk(exc), exec_runner)
+
+
+class _UnavailableSdk:
+    name = "sdk"
+    def __init__(self, error: RunnerCapabilityError): self.error = error
+    def start(self, request): raise self.error
+    def run(self, session, request): raise self.error
+    def resume(self, session, request): raise self.error
+    def review(self, session, request): raise self.error
+    def interrupt(self, session): raise self.error
+    def close(self): return None

--- a/scripts/codex_runner.py
+++ b/scripts/codex_runner.py
@@ -41,7 +41,7 @@ class RunnerRequest:
     mode: str = "run"
     effort: str = "medium"
     sandbox: str | None = None
-    timeout: int = CODEX_EXEC_TIMEOUT
+    timeout: int | None = CODEX_EXEC_TIMEOUT
     unsafe: bool = False
     output_schema: str | None = None
     output_last_message: str | None = None
@@ -196,26 +196,16 @@ class SdkRunner:
         self._threads: dict[str, object] = {}
 
     def _run_thread(self, thread: object, request: RunnerRequest) -> RunnerResult:
-        outcome: dict[str, object] = {}
-        failure: list[BaseException] = []
-
-        def invoke() -> None:
-            try:
-                outcome["result"] = thread.run(request.prompt)
-            except BaseException as exc:  # SDK typed errors vary across pinned runtime surfaces.
-                failure.append(exc)
-
-        worker = threading.Thread(target=invoke, daemon=True)
-        worker.start()
-        worker.join(request.timeout)
-        if worker.is_alive():
-            # ADR-0005 requires bounded, fail-closed cleanup; never report a timed-out turn as success.
-            self._bounded_call(getattr(thread, "interrupt", None))
-            self._bounded_call(getattr(self._codex, "close", None))
-            return RunnerResult(False, self.name, 124, error_kind="timeout")
-        if failure:
-            raise RunnerExecutionError("SDK run failed", recoverable=True) from failure[0]
-        result = outcome.get("result")
+        # The pinned SDK has no cancellable caller-deadline primitive.  Running it
+        # in a daemon thread would let an uninterruptible turn keep modifying the
+        # worktree after Harness reports a timeout, so route deadline-bound work to
+        # the recoverable exec fallback instead.
+        if request.timeout is not None:
+            raise RunnerCapabilityError("SDK bounded timeout is unavailable; use exec fallback")
+        try:
+            result = thread.run(request.prompt)
+        except BaseException as exc:  # SDK typed errors vary across pinned runtime surfaces.
+            raise RunnerExecutionError("SDK run failed", recoverable=True) from exc
         thread_id = getattr(thread, "id", None) or getattr(thread, "thread_id", None)
         return RunnerResult.success(self.name, final_message=str(getattr(result, "final_response", "")), thread_id=thread_id)
 

--- a/scripts/execute.py
+++ b/scripts/execute.py
@@ -29,16 +29,14 @@ from codex_common import (
     CODEX_EXEC_TIMEOUT,
     CODEX_ENV_CONFIG,
     CODEX_ENV_SECRET_FILTER_CONFIG,
-    codex_base_cmd,
     configure_utf8_stdio,
     read_acceptance_commands,
-    resolve_codex_bin,
     validate_codex_effort,
 )
+from codex_runner import RunnerRequest, build_runner
 
 ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_CODEX_EFFORT = "medium"
-CODEX_BIN = resolve_codex_bin()
 
 
 class GuardrailReferenceError(RuntimeError):
@@ -598,54 +596,28 @@ class StepExecutor:
 
         # step 문서는 _build_preamble에서 필요한 섹션만 추려 전달한다.
         # 전체 문서 본문을 다시 붙이면 progressive disclosure 계약을 깨뜨린다.
-        prompt = preamble
-        cmd = codex_base_cmd(self._codex_effort)
-        if self._unsafe:
-            cmd.append("--dangerously-bypass-approvals-and-sandbox")
-        # 프롬프트는 argv 대신 stdin으로 전달해서 ARG_MAX 한계를 피한다.
-        cmd.append("-")
-        try:
-            result = subprocess.run(
-                cmd,
-                input=prompt,
-                cwd=self._root,
-                capture_output=True,
-                text=True,
+        runner = build_runner()
+        result = runner.start(
+            RunnerRequest(
+                prompt=preamble,
+                effort=self._codex_effort,
                 timeout=CODEX_EXEC_TIMEOUT,
+                unsafe=self._unsafe,
             )
-            returncode, stdout, stderr = result.returncode, result.stdout, result.stderr
-        except subprocess.TimeoutExpired as exc:
-            returncode = 124
-            stdout = self._timeout_output(exc.stdout)
-            stderr = self._timeout_output(exc.stderr)
-            timeout_msg = f"codex exec이 {CODEX_EXEC_TIMEOUT}초 안에 끝나지 않아 중단했습니다."
-            stderr = "\n".join(part for part in (stderr, timeout_msg) if part)
-
-        if returncode != 0:
-            print(f"\n  WARN: Codex가 비정상 종료됨 (code {returncode})")
-            if stderr:
-                print(f"  stderr: {stderr[:500]}")
+        )
+        if not result.ok:
+            print(f"\n  WARN: Codex runner가 비정상 종료됨 (code {result.exit_code}, {result.error_kind or 'unknown'})")
 
         output = {
             "step": step_num,
             "name": step_name,
-            "exitCode": returncode,
-            "stdout": stdout,
-            "stderr": stderr,
+            **result.to_record(),
         }
         out_path = self._phase_dir / f"step{step_num}-output.json"
         with open(out_path, "w", encoding="utf-8") as f:
             json.dump(output, f, indent=2, ensure_ascii=False)
 
         return output
-
-    @staticmethod
-    def _timeout_output(value: object) -> str:
-        if value is None:
-            return ""
-        if isinstance(value, bytes):
-            return value.decode("utf-8", "replace")
-        return str(value)
 
     # --- 헤더 & 검증 ---
 

--- a/scripts/tests/test_autopilot.py
+++ b/scripts/tests/test_autopilot.py
@@ -443,6 +443,54 @@ def test_autopilot_delegates_review_to_runner_adapter(runner, monkeypatch):
     assert seen["request"].prompt.startswith("Read-only review only.")
 
 
+def test_runner_process_leaves_timeout_normalization_to_adapter(runner, monkeypatch):
+    def timed_out(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="codex", timeout=1)
+
+    monkeypatch.setattr(ap.subprocess, "run", timed_out)
+    with pytest.raises(subprocess.TimeoutExpired):
+        runner._runner_process(["codex"], input="", capture_output=True, text=True, timeout=1)
+
+
+def test_review_error_still_checks_worktree_immutability(runner, monkeypatch):
+    statuses = iter(["", " M unsafe.py"])
+    runner._worktree_status = lambda: next(statuses)
+
+    class FailingRunner:
+        def review(self, session, request):
+            raise __import__("codex_runner").RunnerExecutionError("timeout")
+
+    monkeypatch.setattr(ap, "build_runner", lambda **kwargs: FailingRunner())
+    review = runner._run_codex_review({"step": 0, "name": "project-scaffold"})
+
+    assert review.passed is False
+    assert "changed the worktree" in review.findings[0]
+
+
+def test_review_and_fix_use_separate_sessions(runner, tmp_repo, monkeypatch):
+    calls = []
+
+    class FakeRunner:
+        name = "sdk"
+
+        def start(self, request):
+            calls.append("start")
+            return __import__("codex_runner").RunnerResult.success("sdk", thread_id="fix-session")
+
+        def resume(self, session, request):
+            calls.append("resume")
+            return __import__("codex_runner").RunnerResult.success("sdk", thread_id="fix-session")
+
+    monkeypatch.setattr(ap, "build_runner", lambda **kwargs: FakeRunner())
+    runner._runner_sessions[0] = __import__("codex_runner").RunnerSession("sdk", "review-session")
+    issue = ap.IssueRecord(1, "title", "body", tmp_repo / "issues" / "issue-1.md", "")
+
+    runner._invoke_codex_fix(issue, "codex/test", {"step": 0, "name": "project-scaffold"}, ap.ReviewResult(False, [], ""), 1)
+    runner._invoke_codex_fix(issue, "codex/test", {"step": 0, "name": "project-scaffold"}, ap.ReviewResult(False, [], ""), 2)
+
+    assert calls == ["start", "resume"]
+
+
 def test_codex_review_parses_output_last_message(runner):
     runner._git = lambda *args, check=True: cp(stdout="")
 

--- a/scripts/tests/test_autopilot.py
+++ b/scripts/tests/test_autopilot.py
@@ -410,7 +410,7 @@ def test_codex_review_uses_step_scoped_exec_prompt(runner):
     review = runner._run_codex_review({"step": 0, "name": "project-scaffold"})
 
     assert review.passed is True
-    assert seen["cmd"][:2] == [ap.CODEX_BIN, "exec"]
+    assert seen["cmd"][1] == "exec"
     assert "review" not in seen["cmd"][2:]
     assert "--base" not in seen["cmd"]
     assert ap.CODEX_ENV_CONFIG in seen["cmd"]
@@ -422,6 +422,25 @@ def test_codex_review_uses_step_scoped_exec_prompt(runner):
     assert seen["cmd"][-1] == "-"
     assert seen["input_text"].startswith("Read-only review only.")
     assert "Current Harness step is Step 0 `project-scaffold`" in seen["input_text"]
+
+
+def test_autopilot_delegates_review_to_runner_adapter(runner, monkeypatch):
+    seen = {}
+    runner._git = lambda *args, check=True: cp(stdout="")
+
+    class FakeRunner:
+        def review(self, session, request):
+            seen["request"] = request
+            return __import__("codex_runner").RunnerResult.success(
+                "exec", final_message='{"pass": true, "summary": "ok", "findings": []}'
+            )
+
+    monkeypatch.setattr(ap, "build_runner", lambda **kwargs: FakeRunner())
+    review = runner._run_codex_review({"step": 0, "name": "project-scaffold"})
+
+    assert review.passed is True
+    assert seen["request"].mode == "review"
+    assert seen["request"].prompt.startswith("Read-only review only.")
 
 
 def test_codex_review_parses_output_last_message(runner):
@@ -520,7 +539,7 @@ def test_codex_fix_uses_medium_reasoning_effort(runner, tmp_repo):
         1,
     )
 
-    assert seen["cmd"][:2] == [ap.CODEX_BIN, "exec"]
+    assert seen["cmd"][1] == "exec"
     assert 'model_reasoning_effort="medium"' in seen["cmd"]
     assert ap.CODEX_ENV_CONFIG in seen["cmd"]
     assert ap.CODEX_ENV_SECRET_FILTER_CONFIG in seen["cmd"]

--- a/scripts/tests/test_codex_common.py
+++ b/scripts/tests/test_codex_common.py
@@ -202,23 +202,16 @@ def test_executor_and_autopilot_do_not_assemble_codex_argv_directly():
         assert "resolve_codex_bin" not in source
 
 
-def test_sdk_timeout_is_fail_closed_after_bounded_cleanup():
+def test_sdk_deadline_is_rejected_before_an_unbounded_turn_starts():
     class Thread:
         id = "ephemeral-thread"
 
         def run(self, prompt):
-            __import__("time").sleep(0.05)
-
-        def interrupt(self):
-            return None
+            raise AssertionError("deadline-bound SDK turn must not start")
 
     runner = codex_runner.SdkRunner.__new__(codex_runner.SdkRunner)
-    runner._codex = type("Client", (), {"close": lambda self: None})()
-    result = runner._run_thread(Thread(), codex_runner.RunnerRequest(prompt="slow", timeout=0))
-
-    assert result.ok is False
-    assert result.exit_code == 124
-    assert result.error_kind == "timeout"
+    with pytest.raises(codex_runner.RunnerCapabilityError, match="bounded timeout"):
+        runner._run_thread(Thread(), codex_runner.RunnerRequest(prompt="slow", timeout=0))
 
 
 def test_sdk_explicit_interrupt_is_bounded_and_fail_closed():

--- a/scripts/tests/test_codex_common.py
+++ b/scripts/tests/test_codex_common.py
@@ -4,6 +4,7 @@ import tomllib
 import pytest
 
 import codex_common
+import codex_runner
 
 
 def test_validate_codex_effort_rejects_xhigh_without_flag():
@@ -107,3 +108,114 @@ def test_read_acceptance_commands_extracts_fenced_commands(tmp_path):
 
 def test_configure_utf8_stdio_is_safe_to_call():
     codex_common.configure_utf8_stdio()
+
+
+def test_runner_uses_exec_by_default_and_sdk_requires_explicit_opt_in(monkeypatch):
+    monkeypatch.delenv("HARNESS_CODEX_RUNNER", raising=False)
+    assert codex_runner.runner_preference() == "exec"
+
+    monkeypatch.setenv("HARNESS_CODEX_RUNNER", "sdk")
+    assert codex_runner.runner_preference() == "sdk"
+
+
+def test_runner_rejects_unknown_preference_fail_closed(monkeypatch):
+    monkeypatch.setenv("HARNESS_CODEX_RUNNER", "unknown")
+    with pytest.raises(codex_runner.RunnerCapabilityError, match="HARNESS_CODEX_RUNNER"):
+        codex_runner.runner_preference()
+
+
+def test_exec_adapter_normalizes_thread_id_without_exposing_it_in_result():
+    completed = __import__("subprocess").CompletedProcess(
+        ["codex"], 0, '{"thread_id":"thread-secret","type":"turn.completed"}\n', ""
+    )
+    runner = codex_runner.ExecRunner(run_process=lambda *args, **kwargs: completed)
+
+    result = runner.run(codex_runner.RunnerSession("exec"), codex_runner.RunnerRequest(prompt="test"))
+
+    assert result.ok is True
+    assert result.thread_id == "thread-secret"
+    assert "thread-secret" not in result.to_record()
+
+
+def test_exec_adapter_resume_uses_session_id_and_preserves_stdin_safety():
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
+        seen["input"] = kwargs["input"]
+        return __import__("subprocess").CompletedProcess(cmd, 0, "", "")
+
+    runner = codex_runner.ExecRunner(run_process=fake_run)
+    runner.resume(codex_runner.RunnerSession("exec", "safe-session"), codex_runner.RunnerRequest(prompt="continue"))
+
+    assert seen["cmd"][1:3] == ["exec", "resume"]
+    assert "safe-session" in seen["cmd"]
+    assert seen["cmd"][-1] == "-"
+    assert seen["input"] == "continue"
+
+
+def test_sdk_capability_failure_falls_back_once_to_exec():
+    fallback = []
+
+    class BrokenSdk:
+        name = "sdk"
+
+        def start(self, request):
+            raise codex_runner.RunnerCapabilityError("pinned runtime mismatch")
+
+    class Exec:
+        name = "exec"
+
+        def start(self, request):
+            fallback.append(request)
+            return codex_runner.RunnerResult.success("exec", fallback_reason="pinned runtime mismatch")
+
+    result = codex_runner.FallbackRunner(BrokenSdk(), Exec()).start(codex_runner.RunnerRequest(prompt="safe"))
+    assert result.ok is True
+    assert result.adapter == "exec"
+    assert result.fallback_reason == "pinned runtime mismatch"
+    assert len(fallback) == 1
+
+
+def test_nonrecoverable_sdk_error_does_not_fallback():
+    class BrokenSdk:
+        name = "sdk"
+
+        def start(self, request):
+            raise codex_runner.RunnerExecutionError("approval denied", recoverable=False)
+
+    class Exec:
+        name = "exec"
+
+        def start(self, request):
+            raise AssertionError("non-recoverable errors must not retry through exec")
+
+    with pytest.raises(codex_runner.RunnerExecutionError, match="approval denied"):
+        codex_runner.FallbackRunner(BrokenSdk(), Exec()).start(codex_runner.RunnerRequest(prompt="safe"))
+
+
+def test_executor_and_autopilot_do_not_assemble_codex_argv_directly():
+    root = Path(__file__).resolve().parents[2]
+    for path in (root / "scripts" / "execute.py", root / "scripts" / "autopilot.py"):
+        source = path.read_text(encoding="utf-8")
+        assert "codex_base_cmd" not in source
+        assert "resolve_codex_bin" not in source
+
+
+def test_sdk_timeout_is_fail_closed_after_bounded_cleanup():
+    class Thread:
+        id = "ephemeral-thread"
+
+        def run(self, prompt):
+            __import__("time").sleep(0.05)
+
+        def interrupt(self):
+            return None
+
+    runner = codex_runner.SdkRunner.__new__(codex_runner.SdkRunner)
+    runner._codex = type("Client", (), {"close": lambda self: None})()
+    result = runner._run_thread(Thread(), codex_runner.RunnerRequest(prompt="slow", timeout=0))
+
+    assert result.ok is False
+    assert result.exit_code == 124
+    assert result.error_kind == "timeout"

--- a/scripts/tests/test_codex_common.py
+++ b/scripts/tests/test_codex_common.py
@@ -219,3 +219,14 @@ def test_sdk_timeout_is_fail_closed_after_bounded_cleanup():
     assert result.ok is False
     assert result.exit_code == 124
     assert result.error_kind == "timeout"
+
+
+def test_sdk_explicit_interrupt_is_bounded_and_fail_closed():
+    runner = codex_runner.SdkRunner.__new__(codex_runner.SdkRunner)
+    runner._threads = {"thread": type("Thread", (), {"interrupt": lambda self: None})()}
+    runner._bounded_call = lambda callback: False
+
+    result = runner.interrupt(codex_runner.RunnerSession("sdk", "thread"))
+
+    assert result.ok is False
+    assert result.error_kind == "interrupt_timeout"

--- a/scripts/tests/test_execute.py
+++ b/scripts/tests/test_execute.py
@@ -750,6 +750,21 @@ class TestStepOnly:
 # ---------------------------------------------------------------------------
 
 class TestInvokeCodex:
+    def test_executor_delegates_codex_invocation_to_runner_adapter(self, executor, monkeypatch):
+        seen = {}
+
+        class FakeRunner:
+            def start(self, request):
+                seen["request"] = request
+                return __import__("codex_runner").RunnerResult.success("exec")
+
+        monkeypatch.setattr(ex, "build_runner", lambda **kwargs: FakeRunner())
+        output = executor._invoke_codex({"step": 2, "name": "ui"}, "PREAMBLE")
+
+        assert seen["request"].prompt == "PREAMBLE"
+        assert output["adapter"] == "exec"
+        assert "stdout" not in output
+
     def test_invokes_codex_with_correct_args(self, executor):
         mock_result = MagicMock(returncode=0, stdout='{"result": "ok"}', stderr="")
         step = {"step": 2, "name": "ui"}
@@ -759,7 +774,6 @@ class TestInvokeCodex:
             output = executor._invoke_codex(step, preamble)
 
         cmd = mock_run.call_args[0][0]
-        assert cmd[0] == ex.CODEX_BIN
         assert cmd[1] == "exec"
         assert "--json" in cmd
         assert ex.CODEX_ENV_CONFIG in cmd
@@ -779,7 +793,7 @@ class TestInvokeCodex:
             executor._invoke_codex(step, "preamble")
 
         cmd = mock_run.call_args[0][0]
-        assert cmd[:2] == [ex.CODEX_BIN, "exec"]
+        assert cmd[1] == "exec"
         assert 'model_reasoning_effort="high"' in cmd
         assert ex.CODEX_ENV_CONFIG in cmd
         assert ex.CODEX_ENV_SECRET_FILTER_CONFIG in cmd
@@ -879,9 +893,10 @@ class TestInvokeCodex:
             output = executor._invoke_codex(step, "preamble")
 
         assert output["exitCode"] == 124
-        assert "1800초" in output["stderr"]
+        assert output["errorKind"] == "timeout"
         saved = json.loads((executor._phase_dir / "step2-output.json").read_text(encoding="utf-8"))
         assert saved["exitCode"] == 124
+        assert "stderr" not in saved
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 작업 내용

- `harness-v2-modernization` Step 6 `runner-adapter`를 구현했습니다.
- `Closes #19`

## contract / adapter / fallback

- `start`, `run`, `resume`, `review`, `interrupt`, `close` 공통 contract와 비민감 정규화 결과를 `scripts/codex_runner.py`에 분리했습니다.
- production 기본은 `codex exec`이며, Python SDK는 `HARNESS_CODEX_RUNNER=sdk`일 때만 opt-in합니다.
- SDK pin/capability/실행의 recoverable 오류만 기존 sandbox·approval·환경 설정을 보존한 exec 경로로 fallback합니다. approval 거부 등 non-recoverable 오류는 retry/fallback하지 않습니다.
- caller deadline이 있는 SDK turn은 안전한 취소 보장이 없어 시작 전에 거부하고 exec으로 fallback합니다. 명시적 SDK interrupt/client close는 bounded, fail-closed 처리합니다.
- thread ID·prompt·raw stdout/stderr는 phase artifact에 기록하지 않습니다. `execute.py`와 `autopilot.py`는 Codex argv/SDK 세부사항을 직접 조립하지 않습니다.

## 검증

- `uv run --isolated --no-project --with pytest python -X utf8 -m pytest scripts/tests/test_codex_common.py scripts/tests/test_execute.py scripts/tests/test_autopilot.py -q` — 145 passed
- `uv run --isolated --no-project --with pytest python -X utf8 -m pytest scripts -q` — 259 passed
- `uv run --isolated --no-project python -X utf8 scripts/doctor.py --template` — passed
- `uv run --isolated --no-project python -X utf8 -m compileall scripts` — passed
- `uv run --isolated --no-project python -X utf8 scripts/checks.py --docs-check-config phases/harness-v2-modernization/docs-checks.json --docs-check` — passed
- `git diff --check` — passed
- 기본 `python`은 PATH에 없어 `uv` 격리 런타임을 사용했습니다.

## review 상태와 한계

- Harness review skill 자체 검토: pass (v1/v2 schema, serial list order, worktree ownership, future-step scope 미변경 확인).
- 승인된 고정 diff를 빈 임시 cwd에서 attached-text-only/stdin-only/read-only로 외부 Codex review했습니다.
- 최초 review P1 3건과 재리뷰 1회의 P1 1건은 같은 branch에서 수정했습니다.
- 재리뷰 2회에서 SDK caller-deadline 잔류 실행 P1을 확인했고, 위 exec fallback 경계로 로컬 수정했습니다.
- 허용된 재리뷰 2회를 모두 사용했으므로 이 head는 외부 CLEAR 미확인입니다. PR은 **Draft / blocked**로 유지하며 Ready 전환·병합·다음 step 진행을 하지 않습니다.
- 상세 복구 조건과 검증 기록은 `issues/harness-v2-modernization/issue-2.md`에 남겼습니다.